### PR TITLE
SDK path for reverse proxy

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.json]
+insert_final_newline = false

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The sooner you instantiate the component, the faster the banner will be displaye
   iabVersion={2} // If you want to support the TCF v1∏, don't forget to change this value, even if you selected the TCF v2 in the console. This parameter will load the correct stub in the React Component
   noticeId="NOTICE_ID" // If you want to target the notice by ID and not by domain
   gdprAppliesGlobally={true}
+  sdkPath="https://sdk.privacy-center.org/"
   onReady={didomi => console.log('Didomi SDK is loaded and ready', didomi)}
   onConsentChanged={cwtToken => console.log('A consent has been given/withdrawn', cwtToken)}
   onNoticeShown={() => console.log('Didomi Notice Shown')}
@@ -82,6 +83,7 @@ const didomiConfig = {
   iabVersion={2} // If you want to support the TCF v1, don't forget to change this value. This parameter will load the correct stub in the React Component
   noticeId="NOTICE_ID" // If you want to target the notice by ID and not by domain
   gdprAppliesGlobally={true}
+  sdkPath="https://sdk.privacy-center.org/"
   onReady={didomi => console.log('Didomi SDK is loaded and ready', didomi)}
   onConsentChanged={cwtToken => console.log('A consent has been given/withdrawn', cwtToken)}
   onNoticeShown={() => console.log('Didomi Notice Shown')}
@@ -145,6 +147,12 @@ The following configuration options can be passed as props to the `DidomiSDK` co
       <td>true</td>
       <td>The banner should display to all users no matter where they are located. If you are a non EU-based company then you are only required to collect consent and show the banner to EU visitors and can configure the banner to do so by changing the  gdprAppliesGlobally variable to false in the tag above (that variable is separate from the window.didomiConfig variable).<br>
       Please note that if you are an EU-based company then you must collect consent and display the banner to all visitors, no matter where they are from.</td>
+    </tr>
+    <tr>
+      <td>sdkPath</td>
+      <td>string</td>
+      <td>https://sdk.privacy-center.org/</td>
+      <td>Path to load the SDK from. This can be used to load the Didomi SDK from your own custom domain after <a href="https://developers.didomi.io/cmp/web-sdk/self-hosting">setting up a reverse proxy</a>. The property must start with <code>http://</code>, <code>https://</code>, or <code>//</code>. It must also end with a final <code>/</code>.</td>
     </tr>
     <tr>
       <td>onReady</td>

--- a/index.d.ts
+++ b/index.d.ts
@@ -111,6 +111,7 @@ declare namespace DidomiReact {
     noticeId?: string;
     config?: IDidomiConfig;
     gdprAppliesGlobally?: boolean;
+    sdkPath?: string;
     onReady?: OnReadyFunction;
     onConsentChanged?: OnConsentChangedFunction;
     onNoticeShown?(): any;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/react",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "devDependencies": {
     "envsub": "^3.1.0",
     "nwb": "0.23.x",
-    "react": "^16.5.2",
-    "react-dom": "^16.5.2"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   },
   "author": "Didomi",
   "homepage": "https://www.didomi.io/",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "react": "16.x"
+    "react": "^16.8.0 || ^17.0.0"
   },
   "devDependencies": {
     "envsub": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
     "react-dom": "^16.5.2"
   },
   "author": "Didomi",
-  "homepage": "https://www.didomi.io/fr/",
+  "homepage": "https://www.didomi.io/",
   "license": "MIT",
   "keywords": [
     "didomi",
     "sdk",
-    "dgpr",
+    "gdpr",
     "react"
   ],
   "repository": {

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  singleQuote: true,
+  trailingComma: "all",
+};

--- a/src/index.js
+++ b/src/index.js
@@ -150,6 +150,9 @@ const DidomiSDK = ({
     let gdprAppliesGlobally = gdprAppliesGloballyProp === false ? false : true;
     window.didomiConfig = config || {};
 
+    // Set the SDK path
+    window.didomiConfig.sdkPath = sdkPath;
+
     // Embed the Didomi SDK on the page
     window.gdprAppliesGlobally=gdprAppliesGlobally;
     if(noticeId) {

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ const DidomiSDK = ({
   onPreferencesClickVendorAgree =  () => {},
   onPreferencesClickVendorDisagree =  () => {},
   onPreferencesClickVendorSaveChoices =  () => {},
-  src = "https://sdk.privacy-center.org/"
+  sdkPath = "https://sdk.privacy-center.org/"
 }) => {
  
   /**
@@ -159,10 +159,10 @@ const DidomiSDK = ({
     }
     if(iabVersion === 2) {
       // TCF v2
-      (function(){function a(e){if(!window.frames[e]){if(document.body&&document.body.firstChild){var t=document.body;var n=document.createElement("iframe");n.style.display="none";n.name=e;n.title=e;t.insertBefore(n,t.firstChild)}else{setTimeout(function(){a(e)},5)}}}function e(n,r,o,c,s){function e(e,t,n,a){if(typeof n!=="function"){return}if(!window[r]){window[r]=[]}var i=false;if(s){i=s(e,t,n)}if(!i){window[r].push({command:e,parameter:t,callback:n,version:a})}}e.stub=true;function t(a){if(!window[n]||window[n].stub!==true){return}if(!a.data){return}var i=typeof a.data==="string";var e;try{e=i?JSON.parse(a.data):a.data}catch(t){return}if(e[o]){var r=e[o];window[n](r.command,r.parameter,function(e,t){var n={};n[c]={returnValue:e,success:t,callId:r.callId};a.source.postMessage(i?JSON.stringify(n):n,"*")},r.version)}}if(typeof window[n]!=="function"){window[n]=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}}e("__tcfapi","__tcfapiBuffer","__tcfapiCall","__tcfapiReturn");a("__tcfapiLocator");(function(e){var t=document.createElement("script");t.id="spcloader";t.type="text/javascript";t.async=true;t.src=src+e+"/loader.js?"+loaderParams;t.charset="utf-8";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n)})(apiKey)})();
+      (function(){function a(e){if(!window.frames[e]){if(document.body&&document.body.firstChild){var t=document.body;var n=document.createElement("iframe");n.style.display="none";n.name=e;n.title=e;t.insertBefore(n,t.firstChild)}else{setTimeout(function(){a(e)},5)}}}function e(n,r,o,c,s){function e(e,t,n,a){if(typeof n!=="function"){return}if(!window[r]){window[r]=[]}var i=false;if(s){i=s(e,t,n)}if(!i){window[r].push({command:e,parameter:t,callback:n,version:a})}}e.stub=true;function t(a){if(!window[n]||window[n].stub!==true){return}if(!a.data){return}var i=typeof a.data==="string";var e;try{e=i?JSON.parse(a.data):a.data}catch(t){return}if(e[o]){var r=e[o];window[n](r.command,r.parameter,function(e,t){var n={};n[c]={returnValue:e,success:t,callId:r.callId};a.source.postMessage(i?JSON.stringify(n):n,"*")},r.version)}}if(typeof window[n]!=="function"){window[n]=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}}e("__tcfapi","__tcfapiBuffer","__tcfapiCall","__tcfapiReturn");a("__tcfapiLocator");(function(e){var t=document.createElement("script");t.id="spcloader";t.type="text/javascript";t.async=true;t.src=sdkPath+e+"/loader.js?"+loaderParams;t.charset="utf-8";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n)})(apiKey)})();
     } else {
       // TCF v1
-      (function(){function r(){if(!window.frames.__cmpLocator){if(document.body&&document.body.firstChild){var e=document.body;var t=document.createElement("iframe");t.style.display="none";t.name="__cmpLocator";t.title="cmpLocator";e.insertBefore(t,e.firstChild)}else{setTimeout(r,5)}}}function e(e,t,r){if(typeof r!=="function"){return}if(!window.__cmpBuffer){window.__cmpBuffer=[]}if(e==="ping"){r({gdprAppliesGlobally:window.gdprAppliesGlobally,cmpLoaded:false},true)}else{window.__cmpBuffer.push({command:e,parameter:t,callback:r})}}e.stub=true;function t(a){if(!window.__cmp||window.__cmp.stub!==true){return}if(!a.data){return}var n=typeof a.data==="string";var e;try{e=n?JSON.parse(a.data):a.data}catch(t){return}if(e.__cmpCall){var o=e.__cmpCall;window.__cmp(o.command,o.parameter,function(e,t){var r={__cmpReturn:{returnValue:e,success:t,callId:o.callId}};a.source.postMessage(n?JSON.stringify(r):r,"*")})}}if(typeof window.__cmp!=="function"){window.__cmp=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}r()})();(function(e){var t=e?e+"/":"";var r=document.createElement("script");r.id="spcloader";r.type="text/javascript";r.async=true;r.src=src+t+"loader.js?"+loaderParams;r.charset="utf-8";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a)})(apiKey);
+      (function(){function r(){if(!window.frames.__cmpLocator){if(document.body&&document.body.firstChild){var e=document.body;var t=document.createElement("iframe");t.style.display="none";t.name="__cmpLocator";t.title="cmpLocator";e.insertBefore(t,e.firstChild)}else{setTimeout(r,5)}}}function e(e,t,r){if(typeof r!=="function"){return}if(!window.__cmpBuffer){window.__cmpBuffer=[]}if(e==="ping"){r({gdprAppliesGlobally:window.gdprAppliesGlobally,cmpLoaded:false},true)}else{window.__cmpBuffer.push({command:e,parameter:t,callback:r})}}e.stub=true;function t(a){if(!window.__cmp||window.__cmp.stub!==true){return}if(!a.data){return}var n=typeof a.data==="string";var e;try{e=n?JSON.parse(a.data):a.data}catch(t){return}if(e.__cmpCall){var o=e.__cmpCall;window.__cmp(o.command,o.parameter,function(e,t){var r={__cmpReturn:{returnValue:e,success:t,callId:o.callId}};a.source.postMessage(n?JSON.stringify(r):r,"*")})}}if(typeof window.__cmp!=="function"){window.__cmp=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}r()})();(function(e){var t=e?e+"/":"";var r=document.createElement("script");r.id="spcloader";r.type="text/javascript";r.async=true;r.src=sdkPath+t+"loader.js?"+loaderParams;r.charset="utf-8";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a)})(apiKey);
     }
   }
 
@@ -200,7 +200,7 @@ DidomiSDK.propTypes = {
   onPreferencesClickVendorAgree: PropTypes.func,
   onPreferencesClickVendorDisagree: PropTypes.func,
   onPreferencesClickVendorSaveChoices: PropTypes.func,
-  src: PropTypes.string
+  sdkPath: PropTypes.string
 }
 
 export { DidomiSDK }

--- a/src/index.js
+++ b/src/index.js
@@ -1,155 +1,131 @@
-import { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
-class DidomiSDK extends Component {
-  static propTypes = {
-    apiKey: PropTypes.string,
-    iabVersion: PropTypes.number,
-    noticeId: PropTypes.string,
-    config: PropTypes.object,
-    gdprAppliesGlobally: PropTypes.bool,
-    onReady: PropTypes.func,
-    onConsentChanged: PropTypes.func,
-    onNoticeShown: PropTypes.func,
-    onNoticeHidden: PropTypes.func,
-    onNoticeBackdropclick: PropTypes.func,
-    onNoticeClickAgree: PropTypes.func,
-    onNoticeClickMoreInfo: PropTypes.func,
-    onPreferencesClickAgreeToAll: PropTypes.func,
-    onPreferencesClickDisagreeToAll: PropTypes.func,
-    onPreferencesClickPurposeAgree: PropTypes.func,
-    onPreferencesClickPurposeDisagree: PropTypes.func,
-    onPreferencesClickViewVendors: PropTypes.func,
-    onPreferencesClickSaveChoices: PropTypes.func,
-    onPreferencesClickVendorAgree: PropTypes.func,
-    onPreferencesClickVendorDisagree: PropTypes.func,
-    onPreferencesClickVendorSaveChoices: PropTypes.func
-  }
-
-  static defaultProps = {
-    apiKey: null,
-    iabVersion: 1,
-    noticeId: null,
-    config: {},
-    gdprAppliesGlobally: true,
-    onReady: () => {},
-    onConsentChanged: () => {},
-    onNoticeShown: () => {},
-    onNoticeHidden: () => {},
-    onNoticeBackdropclick: () => {},
-    onNoticeClickAgree: () => {},
-    onNoticeClickMoreInfo: () => {},
-    onPreferencesClickAgreeToAll: () => {},
-    onPreferencesClickDisagreeToAll: () => {},
-    onPreferencesClickPurposeAgree: () => {},
-    onPreferencesClickPurposeDisagree: () => {},
-    onPreferencesClickViewVendors: () => {},
-    onPreferencesClickSaveChoices: () => {},
-    onPreferencesClickVendorAgree: () => {},
-    onPreferencesClickVendorDisagree: () => {},
-    onPreferencesClickVendorSaveChoices: () => {}
-  }
-
+const DidomiSDK = ({
+  apiKey: apiKeyProp =  null,
+  iabVersion =  1,
+  noticeId =  null,
+  config =  {},
+  gdprAppliesGlobally: gdprAppliesGloballyProp =  true,
+  onReady =  () => {},
+  onConsentChanged =  () => {},
+  onNoticeShown =  () => {},
+  onNoticeHidden =  () => {},
+  onNoticeBackdropclick =  () => {},
+  onNoticeClickAgree =  () => {},
+  onNoticeClickMoreInfo =  () => {},
+  onPreferencesClickAgreeToAll =  () => {},
+  onPreferencesClickDisagreeToAll =  () => {},
+  onPreferencesClickPurposeAgree =  () => {},
+  onPreferencesClickPurposeDisagree =  () => {},
+  onPreferencesClickViewVendors =  () => {},
+  onPreferencesClickSaveChoices =  () => {},
+  onPreferencesClickVendorAgree =  () => {},
+  onPreferencesClickVendorDisagree =  () => {},
+  onPreferencesClickVendorSaveChoices =  () => {},
+  src = "https://sdk.privacy-center.org/"
+}) => {
+ 
   /**
    * Called once the Didomi SDK is ready and loaded
    * @param {*} Didomi
    */
-  didomiOnReady(Didomi) {
-    this.props.onReady(Didomi)
-    this.setEvents(Didomi);
+  const handleDidomiOnReady = (Didomi) => {
+    onReady(Didomi)
+    setEvents(Didomi);
   }
 
   /**
    * Set all the Didomi events the return the callbacks from the props
    * @param {*} Didomi
    */
-  setEvents(Didomi) {
-    if(this.props.onConsentChanged) {
+  const setEvents = (Didomi) => {
+    if(onConsentChanged) {
       Didomi.on('consent.changed', e => {
-        this.props.onConsentChanged(e.consentToken)
+        onConsentChanged(e.consentToken)
       })
     }
 
-    if(this.props.onNoticeShown) {
+    if(onNoticeShown) {
       Didomi.on('notice.shown', e => {
-        this.props.onNoticeShown()
+        onNoticeShown()
       })
     }
 
-    if(this.props.onNoticeHidden) {
+    if(onNoticeHidden) {
       Didomi.on('notice.hidden', e => {
-        this.props.onNoticeHidden()
+        onNoticeHidden()
       })
     }
 
-    if(this.props.onNoticeBackdropclick) {
+    if(onNoticeBackdropclick) {
       Didomi.on('notice.backdropclick', e => {
-        this.props.onNoticeBackdropclick()
+        onNoticeBackdropclick()
       })
     }
 
-    if(this.props.onNoticeClickAgree) {
+    if(onNoticeClickAgree) {
       Didomi.on('notice.clickagree', e => {
-        this.props.onNoticeClickAgree()
+        onNoticeClickAgree()
       })
     }
 
-    if(this.props.onNoticeClickMoreInfo) {
+    if(onNoticeClickMoreInfo) {
       Didomi.on('notice.clickmoreinfo', e => {
-        this.props.onNoticeClickMoreInfo()
+        onNoticeClickMoreInfo()
       })
     }
 
-    if(this.props.onPreferencesClickAgreeToAll) {
+    if(onPreferencesClickAgreeToAll) {
       Didomi.on('preferences.clickagreetoall', e => {
-        this.props.onPreferencesClickAgreeToAll()
+        onPreferencesClickAgreeToAll()
       })
     }
 
-    if(this.props.onPreferencesClickDisagreeToAll) {
+    if(onPreferencesClickDisagreeToAll) {
       Didomi.on('preferences.clickdisagreetoall', e => {
-        this.props.onPreferencesClickDisagreeToAll()
+        onPreferencesClickDisagreeToAll()
       })
     }
-    if(this.props.onPreferencesClickPurposeAgree) {
+    if(onPreferencesClickPurposeAgree) {
       Didomi.on('preferences.clickpurposeagree', e => {
-        this.props.onPreferencesClickPurposeAgree(e.purposeId)
+        onPreferencesClickPurposeAgree(e.purposeId)
       })
     }
 
-    if(this.props.onPreferencesClickPurposeDisagree) {
+    if(onPreferencesClickPurposeDisagree) {
       Didomi.on('preferences.clickpurposedisagree', e => {
-        this.props.onPreferencesClickPurposeDisagree(e.purposeId)
+        onPreferencesClickPurposeDisagree(e.purposeId)
       })
     }
 
-    if(this.props.onPreferencesClickViewVendors) {
+    if(onPreferencesClickViewVendors) {
       Didomi.on('preferences.clickviewvendors', e => {
-        this.props.onPreferencesClickViewVendors()
+        onPreferencesClickViewVendors()
       })
     }
 
-    if(this.props.onPreferencesClickSaveChoices) {
+    if(onPreferencesClickSaveChoices) {
       Didomi.on('preferences.clicksavechoices', e => {
-        this.props.onPreferencesClickSaveChoices()
+        onPreferencesClickSaveChoices()
       })
     }
 
-    if(this.props.onPreferencesClickVendorAgree) {
+    if(onPreferencesClickVendorAgree) {
       Didomi.on('preferences.clickvendoragree', e => {
-        this.props.onPreferencesClickVendorAgree(e.vendorId)
+        onPreferencesClickVendorAgree(e.vendorId)
       })
     }
 
-    if(this.props.onPreferencesClickVendorDisagree) {
+    if(onPreferencesClickVendorDisagree) {
       Didomi.on('preferences.clickvendordisagree', e => {
-        this.props.onPreferencesClickVendorDisagree(e.vendorId)
+        onPreferencesClickVendorDisagree(e.vendorId)
       })
     }
 
-    if(this.props.onPreferencesClickVendorSaveChoices) {
+    if(onPreferencesClickVendorSaveChoices) {
       Didomi.on('preferences.clickvendorsavechoices', e => {
-        this.props.onPreferencesClickVendorSaveChoices()
+        onPreferencesClickVendorSaveChoices()
       })
     }
   }
@@ -157,51 +133,74 @@ class DidomiSDK extends Component {
   /**
    * Get the API Key from the props or from the config if it exists
    */
-  getApiKey() {
+  const getApiKey = () => {
     let apiKey;
-    if(this.props.config.app && this.props.config.app.apiKey) {
-      apiKey = this.props.config.app.apiKey
+    if(config.app && config.app.apiKey) {
+      apiKey = config.app.apiKey
     }
-    return this.props.apiKey || apiKey;
+    return apiKeyProp || apiKey;
   }
 
   /**
    * Initialize the SDK, set the config object and insert the loader.js into the DOM
    */
-  init() {
+  const init = () => {
     let loaderParams;
-    let apiKey = this.getApiKey();
-    let gdprAppliesGlobally = this.props.gdprAppliesGlobally === false ? false : true;
-    window.didomiConfig = this.props.config || {};
+    let apiKey = getApiKey();
+    let gdprAppliesGlobally = gdprAppliesGloballyProp === false ? false : true;
+    window.didomiConfig = config || {};
 
     // Embed the Didomi SDK on the page
     window.gdprAppliesGlobally=gdprAppliesGlobally;
-    if(this.props.noticeId) {
-      loaderParams = `target_type=notice&target=${this.props.noticeId}`;
+    if(noticeId) {
+      loaderParams = `target_type=notice&target=${noticeId}`;
     } else {
       loaderParams = `target=${document.location.hostname}`;
     }
-    if(this.props.iabVersion === 2) {
+    if(iabVersion === 2) {
       // TCF v2
-      (function(){function a(e){if(!window.frames[e]){if(document.body&&document.body.firstChild){var t=document.body;var n=document.createElement("iframe");n.style.display="none";n.name=e;n.title=e;t.insertBefore(n,t.firstChild)}else{setTimeout(function(){a(e)},5)}}}function e(n,r,o,c,s){function e(e,t,n,a){if(typeof n!=="function"){return}if(!window[r]){window[r]=[]}var i=false;if(s){i=s(e,t,n)}if(!i){window[r].push({command:e,parameter:t,callback:n,version:a})}}e.stub=true;function t(a){if(!window[n]||window[n].stub!==true){return}if(!a.data){return}var i=typeof a.data==="string";var e;try{e=i?JSON.parse(a.data):a.data}catch(t){return}if(e[o]){var r=e[o];window[n](r.command,r.parameter,function(e,t){var n={};n[c]={returnValue:e,success:t,callId:r.callId};a.source.postMessage(i?JSON.stringify(n):n,"*")},r.version)}}if(typeof window[n]!=="function"){window[n]=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}}e("__tcfapi","__tcfapiBuffer","__tcfapiCall","__tcfapiReturn");a("__tcfapiLocator");(function(e){var t=document.createElement("script");t.id="spcloader";t.type="text/javascript";t.async=true;t.src="https://sdk.privacy-center.org/"+e+"/loader.js?"+loaderParams;t.charset="utf-8";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n)})(apiKey)})();
+      (function(){function a(e){if(!window.frames[e]){if(document.body&&document.body.firstChild){var t=document.body;var n=document.createElement("iframe");n.style.display="none";n.name=e;n.title=e;t.insertBefore(n,t.firstChild)}else{setTimeout(function(){a(e)},5)}}}function e(n,r,o,c,s){function e(e,t,n,a){if(typeof n!=="function"){return}if(!window[r]){window[r]=[]}var i=false;if(s){i=s(e,t,n)}if(!i){window[r].push({command:e,parameter:t,callback:n,version:a})}}e.stub=true;function t(a){if(!window[n]||window[n].stub!==true){return}if(!a.data){return}var i=typeof a.data==="string";var e;try{e=i?JSON.parse(a.data):a.data}catch(t){return}if(e[o]){var r=e[o];window[n](r.command,r.parameter,function(e,t){var n={};n[c]={returnValue:e,success:t,callId:r.callId};a.source.postMessage(i?JSON.stringify(n):n,"*")},r.version)}}if(typeof window[n]!=="function"){window[n]=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}}e("__tcfapi","__tcfapiBuffer","__tcfapiCall","__tcfapiReturn");a("__tcfapiLocator");(function(e){var t=document.createElement("script");t.id="spcloader";t.type="text/javascript";t.async=true;t.src=src+e+"/loader.js?"+loaderParams;t.charset="utf-8";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n)})(apiKey)})();
     } else {
       // TCF v1
-      (function(){function r(){if(!window.frames.__cmpLocator){if(document.body&&document.body.firstChild){var e=document.body;var t=document.createElement("iframe");t.style.display="none";t.name="__cmpLocator";t.title="cmpLocator";e.insertBefore(t,e.firstChild)}else{setTimeout(r,5)}}}function e(e,t,r){if(typeof r!=="function"){return}if(!window.__cmpBuffer){window.__cmpBuffer=[]}if(e==="ping"){r({gdprAppliesGlobally:window.gdprAppliesGlobally,cmpLoaded:false},true)}else{window.__cmpBuffer.push({command:e,parameter:t,callback:r})}}e.stub=true;function t(a){if(!window.__cmp||window.__cmp.stub!==true){return}if(!a.data){return}var n=typeof a.data==="string";var e;try{e=n?JSON.parse(a.data):a.data}catch(t){return}if(e.__cmpCall){var o=e.__cmpCall;window.__cmp(o.command,o.parameter,function(e,t){var r={__cmpReturn:{returnValue:e,success:t,callId:o.callId}};a.source.postMessage(n?JSON.stringify(r):r,"*")})}}if(typeof window.__cmp!=="function"){window.__cmp=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}r()})();(function(e){var t=e?e+"/":"";var r=document.createElement("script");r.id="spcloader";r.type="text/javascript";r.async=true;r.src="https://sdk.privacy-center.org/"+t+"loader.js?"+loaderParams;r.charset="utf-8";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a)})(apiKey);
+      (function(){function r(){if(!window.frames.__cmpLocator){if(document.body&&document.body.firstChild){var e=document.body;var t=document.createElement("iframe");t.style.display="none";t.name="__cmpLocator";t.title="cmpLocator";e.insertBefore(t,e.firstChild)}else{setTimeout(r,5)}}}function e(e,t,r){if(typeof r!=="function"){return}if(!window.__cmpBuffer){window.__cmpBuffer=[]}if(e==="ping"){r({gdprAppliesGlobally:window.gdprAppliesGlobally,cmpLoaded:false},true)}else{window.__cmpBuffer.push({command:e,parameter:t,callback:r})}}e.stub=true;function t(a){if(!window.__cmp||window.__cmp.stub!==true){return}if(!a.data){return}var n=typeof a.data==="string";var e;try{e=n?JSON.parse(a.data):a.data}catch(t){return}if(e.__cmpCall){var o=e.__cmpCall;window.__cmp(o.command,o.parameter,function(e,t){var r={__cmpReturn:{returnValue:e,success:t,callId:o.callId}};a.source.postMessage(n?JSON.stringify(r):r,"*")})}}if(typeof window.__cmp!=="function"){window.__cmp=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}r()})();(function(e){var t=e?e+"/":"";var r=document.createElement("script");r.id="spcloader";r.type="text/javascript";r.async=true;r.src=src+t+"loader.js?"+loaderParams;r.charset="utf-8";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a)})(apiKey);
     }
   }
 
-  componentDidMount() {
-    this.init();
+  React.useEffect(() => {
+    init();
 
-    if(this.props.onReady) {
+    if(onReady) {
       window.didomiOnReady = window.didomiOnReady || [];
-      window.didomiOnReady.push(this.didomiOnReady.bind(this));
+      window.didomiOnReady.push(handleDidomiOnReady);
     }
-  }
+  }, []) 
 
-  render() {
-    return null;
-  }
-};
+  return null;
+}
+
+DidomiSDK.propTypes = {
+  apiKey: PropTypes.string,
+  iabVersion: PropTypes.number,
+  noticeId: PropTypes.string,
+  config: PropTypes.object,
+  gdprAppliesGlobally: PropTypes.bool,
+  onReady: PropTypes.func,
+  onConsentChanged: PropTypes.func,
+  onNoticeShown: PropTypes.func,
+  onNoticeHidden: PropTypes.func,
+  onNoticeBackdropclick: PropTypes.func,
+  onNoticeClickAgree: PropTypes.func,
+  onNoticeClickMoreInfo: PropTypes.func,
+  onPreferencesClickAgreeToAll: PropTypes.func,
+  onPreferencesClickDisagreeToAll: PropTypes.func,
+  onPreferencesClickPurposeAgree: PropTypes.func,
+  onPreferencesClickPurposeDisagree: PropTypes.func,
+  onPreferencesClickViewVendors: PropTypes.func,
+  onPreferencesClickSaveChoices: PropTypes.func,
+  onPreferencesClickVendorAgree: PropTypes.func,
+  onPreferencesClickVendorDisagree: PropTypes.func,
+  onPreferencesClickVendorSaveChoices: PropTypes.func,
+  src: PropTypes.string
+}
 
 export { DidomiSDK }

--- a/src/index.js
+++ b/src/index.js
@@ -7,126 +7,140 @@ const DidomiSDK = ({
   noticeId =  null,
   config =  {},
   gdprAppliesGlobally: gdprAppliesGloballyProp =  true,
-  onReady =  () => {},
-  onConsentChanged =  () => {},
-  onNoticeShown =  () => {},
-  onNoticeHidden =  () => {},
-  onNoticeBackdropclick =  () => {},
-  onNoticeClickAgree =  () => {},
-  onNoticeClickMoreInfo =  () => {},
-  onPreferencesClickAgreeToAll =  () => {},
-  onPreferencesClickDisagreeToAll =  () => {},
-  onPreferencesClickPurposeAgree =  () => {},
-  onPreferencesClickPurposeDisagree =  () => {},
-  onPreferencesClickViewVendors =  () => {},
-  onPreferencesClickSaveChoices =  () => {},
-  onPreferencesClickVendorAgree =  () => {},
-  onPreferencesClickVendorDisagree =  () => {},
-  onPreferencesClickVendorSaveChoices =  () => {},
+  onReady,
+  onConsentChanged,
+  onNoticeShown,
+  onNoticeHidden,
+  onNoticeBackdropclick,
+  onNoticeClickAgree,
+  onNoticeClickMoreInfo,
+  onPreferencesClickAgreeToAll,
+  onPreferencesClickDisagreeToAll,
+  onPreferencesClickPurposeAgree,
+  onPreferencesClickPurposeDisagree,
+  onPreferencesClickViewVendors,
+  onPreferencesClickSaveChoices,
+  onPreferencesClickVendorAgree,
+  onPreferencesClickVendorDisagree,
+  onPreferencesClickVendorSaveChoices,
   sdkPath = "https://sdk.privacy-center.org/"
 }) => {
- 
   /**
-   * Called once the Didomi SDK is ready and loaded
-   * @param {*} Didomi
+   * Set all the Didomi event listeners from the props
    */
-  const handleDidomiOnReady = (Didomi) => {
-    onReady(Didomi)
-    setEvents(Didomi);
-  }
+  const setEvents = () => {
+    if(onReady) {
+      window.didomiOnReady = window.didomiOnReady || [];
+      window.didomiOnReady.push(onReady);
+    }
 
-  /**
-   * Set all the Didomi events the return the callbacks from the props
-   * @param {*} Didomi
-   */
-  const setEvents = (Didomi) => {
+    window.didomiEventListeners = window.didomiEventListeners || [];
+
     if(onConsentChanged) {
-      Didomi.on('consent.changed', e => {
-        onConsentChanged(e.consentToken)
-      })
+      window.didomiEventListeners.push({
+        event: 'consent.changed',
+        listener: e => {
+          onConsentChanged(e.consentToken)
+        }
+      }); 
     }
 
     if(onNoticeShown) {
-      Didomi.on('notice.shown', e => {
-        onNoticeShown()
-      })
+      window.didomiEventListeners.push({
+        event: 'notice.shown',
+        listener: () => onNoticeShown()
+      });
     }
 
     if(onNoticeHidden) {
-      Didomi.on('notice.hidden', e => {
-        onNoticeHidden()
-      })
+      window.didomiEventListeners.push({
+        event: 'notice.hidden',
+        listener: () => onNoticeHidden()
+      });
     }
 
     if(onNoticeBackdropclick) {
-      Didomi.on('notice.backdropclick', e => {
-        onNoticeBackdropclick()
-      })
+      window.didomiEventListeners.push({
+        event: 'notice.backdropclick',
+        listener: () => onNoticeBackdropclick()
+      });
     }
 
     if(onNoticeClickAgree) {
-      Didomi.on('notice.clickagree', e => {
-        onNoticeClickAgree()
-      })
+      window.didomiEventListeners.push({
+        event: 'notice.clickagree',
+        listener: () => onNoticeClickAgree()
+      });
     }
 
     if(onNoticeClickMoreInfo) {
-      Didomi.on('notice.clickmoreinfo', e => {
-        onNoticeClickMoreInfo()
-      })
+      window.didomiEventListeners.push({
+        event: 'notice.clickmoreinfo',
+        listener: () => onNoticeClickMoreInfo()
+      });
     }
 
     if(onPreferencesClickAgreeToAll) {
-      Didomi.on('preferences.clickagreetoall', e => {
-        onPreferencesClickAgreeToAll()
-      })
+      window.didomiEventListeners.push({
+        event: 'preferences.clickagreetoall',
+        listener: () => onPreferencesClickAgreeToAll()
+      });
     }
 
     if(onPreferencesClickDisagreeToAll) {
-      Didomi.on('preferences.clickdisagreetoall', e => {
-        onPreferencesClickDisagreeToAll()
-      })
+      window.didomiEventListeners.push({
+        event: 'preferences.clickdisagreetoall',
+        listener: () => onPreferencesClickDisagreeToAll()
+      });
     }
+
     if(onPreferencesClickPurposeAgree) {
-      Didomi.on('preferences.clickpurposeagree', e => {
-        onPreferencesClickPurposeAgree(e.purposeId)
-      })
+      window.didomiEventListeners.push({
+        event: 'preferences.clickpurposeagree',
+        listener: () => onPreferencesClickPurposeAgree()
+      });
     }
 
     if(onPreferencesClickPurposeDisagree) {
-      Didomi.on('preferences.clickpurposedisagree', e => {
-        onPreferencesClickPurposeDisagree(e.purposeId)
-      })
+      window.didomiEventListeners.push({
+        event: 'preferences.clickpurposedisagree',
+        listener: () => onPreferencesClickPurposeDisagree()
+      });
     }
 
     if(onPreferencesClickViewVendors) {
-      Didomi.on('preferences.clickviewvendors', e => {
-        onPreferencesClickViewVendors()
-      })
+      window.didomiEventListeners.push({
+        event: 'preferences.clickviewvendors',
+        listener: () => onPreferencesClickViewVendors()
+      });
     }
 
     if(onPreferencesClickSaveChoices) {
-      Didomi.on('preferences.clicksavechoices', e => {
-        onPreferencesClickSaveChoices()
-      })
+      window.didomiEventListeners.push({
+        event: 'preferences.clicksavechoices',
+        listener: () => onPreferencesClickSaveChoices()
+      });
     }
 
     if(onPreferencesClickVendorAgree) {
-      Didomi.on('preferences.clickvendoragree', e => {
-        onPreferencesClickVendorAgree(e.vendorId)
-      })
+      window.didomiEventListeners.push({
+        event: 'preferences.clickvendoragree',
+        listener: () => onPreferencesClickVendorAgree()
+      });
     }
 
     if(onPreferencesClickVendorDisagree) {
-      Didomi.on('preferences.clickvendordisagree', e => {
-        onPreferencesClickVendorDisagree(e.vendorId)
-      })
+      window.didomiEventListeners.push({
+        event: 'preferences.clickvendordisagree',
+        listener: () => onPreferencesClickVendorDisagree()
+      });
     }
 
     if(onPreferencesClickVendorSaveChoices) {
-      Didomi.on('preferences.clickvendorsavechoices', e => {
-        onPreferencesClickVendorSaveChoices()
-      })
+      window.didomiEventListeners.push({
+        event: 'preferences.clickvendorsavechoices',
+        listener: () => onPreferencesClickVendorSaveChoices()
+      });
     }
   }
 
@@ -171,12 +185,8 @@ const DidomiSDK = ({
   }
 
   React.useEffect(() => {
+    setEvents();
     init();
-
-    if(onReady) {
-      window.didomiOnReady = window.didomiOnReady || [];
-      window.didomiOnReady.push(handleDidomiOnReady);
-    }
   }, []) 
 
   return null;

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 const DidomiSDK = ({
   apiKey: apiKeyProp =  null,
-  iabVersion =  1,
+  iabVersion =  2,
   noticeId =  null,
   config =  {},
   gdprAppliesGlobally: gdprAppliesGloballyProp =  true,
@@ -157,6 +157,7 @@ const DidomiSDK = ({
     } else {
       loaderParams = `target=${document.location.hostname}`;
     }
+    
     if(iabVersion === 2) {
       // TCF v2
       (function(){function a(e){if(!window.frames[e]){if(document.body&&document.body.firstChild){var t=document.body;var n=document.createElement("iframe");n.style.display="none";n.name=e;n.title=e;t.insertBefore(n,t.firstChild)}else{setTimeout(function(){a(e)},5)}}}function e(n,r,o,c,s){function e(e,t,n,a){if(typeof n!=="function"){return}if(!window[r]){window[r]=[]}var i=false;if(s){i=s(e,t,n)}if(!i){window[r].push({command:e,parameter:t,callback:n,version:a})}}e.stub=true;function t(a){if(!window[n]||window[n].stub!==true){return}if(!a.data){return}var i=typeof a.data==="string";var e;try{e=i?JSON.parse(a.data):a.data}catch(t){return}if(e[o]){var r=e[o];window[n](r.command,r.parameter,function(e,t){var n={};n[c]={returnValue:e,success:t,callId:r.callId};a.source.postMessage(i?JSON.stringify(n):n,"*")},r.version)}}if(typeof window[n]!=="function"){window[n]=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}}e("__tcfapi","__tcfapiBuffer","__tcfapiCall","__tcfapiReturn");a("__tcfapiLocator");(function(e){var t=document.createElement("script");t.id="spcloader";t.type="text/javascript";t.async=true;t.src=sdkPath+e+"/loader.js?"+loaderParams;t.charset="utf-8";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n)})(apiKey)})();

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -2,30 +2,205 @@ import expect from 'expect';
 import React from 'react';
 import { render } from 'react-dom';
 
-import { DidomiSDK } from 'src/'
+import { DidomiSDK } from 'src/';
 
-describe('DidomiSDK', () => {
-  it('loads and initializes the Didomi SDK', async () => {
-    const div = document.createElement('div');
-    div.id = 'test';
-    document.querySelector('body').appendChild(div);
-    
-    const sdkInstance = <DidomiSDK apiKey="03f1af55-a479-4c1f-891a-7481345171ce" />;
-
-    render(sdkInstance, div);
-
-    expect(sdkInstance).toExist();
-
-    const sdkScript = document.querySelector('script[id="spcloader"]');
-    expect(sdkScript).toExist();
-    expect(sdkScript.src).toEqual('https://sdk.privacy-center.org/03f1af55-a479-4c1f-891a-7481345171ce/loader.js?target=localhost');
-
-    // Ensuring that no error is thrown when a message with invalid JSON is sent to the window
-    window.postMessage('test', '*');
-
-    return new Promise((resolve) => {
-      window.didomiOnReady = window.didomiOnReady || [];
-      window.didomiOnReady.push(resolve);
-    });
+/**
+ * Wait for the SDK to be ready
+ */
+function sdkReady() {
+  return new Promise((resolve) => {
+    window.didomiOnReady = window.didomiOnReady || [];
+    window.didomiOnReady.push(resolve);
   });
-})
+}
+
+/**
+ * Clean up global objects created by the SDK
+ */
+beforeEach(() => {
+  delete window.didomiOnReady;
+  delete window.didomiEventListeners;
+  delete window.Didomi;
+  delete window.didomiConfig;
+  delete window.__tcfapi;
+  delete window.__cmp;
+  delete window.gdprAppliesGlobally;
+});
+
+it('loads and initializes the Didomi SDK (TCFv2)', async () => {
+  render(
+    <DidomiSDK apiKey="03f1af55-a479-4c1f-891a-7481345171ce" iabVersion={2} />,
+    document.body.appendChild(document.createElement('iframe')),
+  );
+
+  await sdkReady();
+
+  // Ensure that the SDK is correctly embedded on the page
+  const sdkScript = document.querySelector('#spcloader');
+  expect(sdkScript).toExist();
+  expect(sdkScript.src).toEqual(
+    'https://sdk.privacy-center.org/03f1af55-a479-4c1f-891a-7481345171ce/loader.js?target=localhost',
+  );
+
+  expect(typeof window.__tcfapi).toEqual('function');
+});
+
+it('loads the Didomi SDK from a specific SDK path (TCFv2)', async () => {
+  render(
+    <DidomiSDK
+      apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+      iabVersion={2}
+      sdkPath="https://sdk.staging.privacy-center.org/"
+    />,
+    document.body.appendChild(document.createElement('DIV')),
+  );
+
+  await sdkReady();
+
+  // Ensure that the SDK is correctly embedded on the page
+  const sdkScript = document.querySelector('#spcloader');
+  expect(sdkScript).toExist();
+  expect(sdkScript.src).toEqual(
+    'https://sdk.staging.privacy-center.org/03f1af55-a479-4c1f-891a-7481345171ce/loader.js?target=localhost',
+  );
+});
+
+it('loads the Didomi SDK with a specific notice ID (TCFv2)', async () => {
+  render(
+    <DidomiSDK
+      apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+      iabVersion={2}
+      noticeId="noticeId"
+    />,
+    document.body.appendChild(document.createElement('DIV')),
+  );
+
+  await sdkReady();
+
+  // Ensure that the SDK is correctly embedded on the page
+  const sdkScript = document.querySelector('#spcloader');
+  expect(sdkScript).toExist();
+  expect(sdkScript.src).toEqual(
+    'https://sdk.privacy-center.org/03f1af55-a479-4c1f-891a-7481345171ce/loader.js?target_type=notice&target=noticeId',
+  );
+});
+
+it('loads and initializes the Didomi SDK (TCFv1)', async () => {
+  render(
+    <DidomiSDK apiKey="03f1af55-a479-4c1f-891a-7481345171ce" iabVersion={1} />,
+    document.body.appendChild(document.createElement('iframe')),
+  );
+
+  await sdkReady();
+
+  // Ensure that the SDK is correctly embedded on the page
+  const sdkScript = document.querySelector('#spcloader');
+  expect(sdkScript).toExist();
+  expect(sdkScript.src).toEqual(
+    'https://sdk.privacy-center.org/03f1af55-a479-4c1f-891a-7481345171ce/loader.js?target=localhost',
+  );
+
+  expect(typeof window.__cmp).toEqual('function');
+});
+
+it('loads the Didomi SDK from a specific SDK path (TCFv1)', async () => {
+  render(
+    <DidomiSDK
+      apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+      iabVersion={1}
+      sdkPath="https://sdk.staging.privacy-center.org/"
+    />,
+    document.body.appendChild(document.createElement('DIV')),
+  );
+
+  await sdkReady();
+
+  // Ensure that the SDK is correctly embedded on the page
+  const sdkScript = document.querySelector('#spcloader');
+  expect(sdkScript).toExist();
+  expect(sdkScript.src).toEqual(
+    'https://sdk.staging.privacy-center.org/03f1af55-a479-4c1f-891a-7481345171ce/loader.js?target=localhost',
+  );
+});
+
+it('loads the Didomi SDK with a specific notice ID (TCFv2)', async () => {
+  render(
+    <DidomiSDK
+      apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+      iabVersion={1}
+      noticeId="noticeId"
+    />,
+    document.body.appendChild(document.createElement('DIV')),
+  );
+
+  await sdkReady();
+
+  // Ensure that the SDK is correctly embedded on the page
+  const sdkScript = document.querySelector('#spcloader');
+  expect(sdkScript).toExist();
+  expect(sdkScript.src).toEqual(
+    'https://sdk.privacy-center.org/03f1af55-a479-4c1f-891a-7481345171ce/loader.js?target_type=notice&target=noticeId',
+  );
+});
+
+it('calls onReady', async () => {
+  let ready = false;
+  const onReady = () => (ready = true);
+
+  render(
+    <DidomiSDK
+      apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+      onReady={onReady}
+    />,
+    document.body.appendChild(document.createElement('iframe')),
+  );
+
+  await sdkReady();
+  expect(ready).toEqual(true);
+});
+
+it('sets the didomiConfig', async () => {
+  const didomiConfig = {
+    key: 'value',
+  };
+
+  render(
+    <DidomiSDK
+      apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+      config={didomiConfig}
+    />,
+    document.body.appendChild(document.createElement('DIV')),
+  );
+
+  await sdkReady();
+
+  expect(window.didomiConfig).toEqual(didomiConfig);
+});
+
+it('sets gdprAppliesGlobally to true', async () => {
+  render(
+    <DidomiSDK
+      apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+      gdprAppliesGlobally={true}
+    />,
+    document.body.appendChild(document.createElement('DIV')),
+  );
+
+  await sdkReady();
+
+  expect(window.gdprAppliesGlobally).toEqual(true);
+});
+
+it('sets gdprAppliesGlobally to false', async () => {
+  render(
+    <DidomiSDK
+      apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+      gdprAppliesGlobally={false}
+    />,
+    document.body.appendChild(document.createElement('DIV')),
+  );
+
+  await sdkReady();
+
+  expect(window.gdprAppliesGlobally).toEqual(false);
+});

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -167,6 +167,33 @@ it('calls onReady', async () => {
   expect(ready).toEqual(true);
 });
 
+it('calls onNoticeShown', (done) => {
+  const eventHandler = () => {
+    done();
+  };
+
+  const config = {
+    app: {
+      vendors: {
+        iab: {
+          enabled: true,
+          all: true,
+        },
+      },
+    },
+  };
+
+  render(
+    <DidomiSDK
+      apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+      config={config}
+      gdprAppliesGlobally={true}
+      onNoticeShown={eventHandler}
+    />,
+    document.body.appendChild(document.createElement('iframe')),
+  );
+});
+
 it('sets the didomiConfig', async () => {
   const didomiConfig = {
     key: 'value',

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -63,6 +63,10 @@ it('loads the Didomi SDK from a specific SDK path (TCFv2)', async () => {
   expect(sdkScript.src).toEqual(
     'https://sdk.staging.privacy-center.org/03f1af55-a479-4c1f-891a-7481345171ce/loader.js?target=localhost',
   );
+
+  expect(window.didomiConfig.sdkPath).toEqual(
+    'https://sdk.staging.privacy-center.org/',
+  );
 });
 
 it('loads the Didomi SDK with a specific notice ID (TCFv2)', async () => {
@@ -120,6 +124,10 @@ it('loads the Didomi SDK from a specific SDK path (TCFv1)', async () => {
   expect(sdkScript).toExist();
   expect(sdkScript.src).toEqual(
     'https://sdk.staging.privacy-center.org/03f1af55-a479-4c1f-891a-7481345171ce/loader.js?target=localhost',
+  );
+
+  expect(window.didomiConfig.sdkPath).toEqual(
+    'https://sdk.staging.privacy-center.org/',
   );
 });
 


### PR DESCRIPTION
Add support for `sdkPath` configuration property to use the SDK provided by a reverse proxy (https://developers.didomi.io/cmp/web-sdk/self-hosting)

Additions to https://github.com/didomi/react/pull/23/files

Closes #22 