### PR TITLE
Disabling TCF stub with tcfEnabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ npm install --save @didomi/react
 import { DidomiSDK } from '@didomi/react';
 ```
 
-We recommend instantiating the `DidomiSDK` component as early as possible in your React application.    
+We recommend instantiating the `DidomiSDK` component as early as possible in your React application.
 The sooner you instantiate the component, the faster the banner will be displayed or the faster the consents will be shared with your partners and the ads displayed.
 
 ## Create the DidomiSDK component
@@ -35,7 +35,7 @@ The sooner you instantiate the component, the faster the banner will be displaye
   noticeId="NOTICE_ID" // If you want to target the notice by ID and not by domain
   gdprAppliesGlobally={true}
   sdkPath="https://sdk.privacy-center.org/"
-  tcfEnabled={true}
+  embedTCFStub={true}
   onReady={didomi => console.log('Didomi SDK is loaded and ready', didomi)}
   onConsentChanged={cwtToken => console.log('A consent has been given/withdrawn', cwtToken)}
   onNoticeShown={() => console.log('Didomi Notice Shown')}
@@ -85,7 +85,7 @@ const didomiConfig = {
   noticeId="NOTICE_ID" // If you want to target the notice by ID and not by domain
   gdprAppliesGlobally={true}
   sdkPath="https://sdk.privacy-center.org/"
-  tcfEnabled={true}
+  embedTCFStub={true}
   onReady={didomi => console.log('Didomi SDK is loaded and ready', didomi)}
   onConsentChanged={cwtToken => console.log('A consent has been given/withdrawn', cwtToken)}
   onNoticeShown={() => console.log('Didomi Notice Shown')}
@@ -157,10 +157,10 @@ The following configuration options can be passed as props to the `DidomiSDK` co
       <td>Path to load the SDK from. This can be used to load the Didomi SDK from your own custom domain after <a href="https://developers.didomi.io/cmp/web-sdk/self-hosting">setting up a reverse proxy</a>. The property must start with <code>http://</code>, <code>https://</code>, or <code>//</code>. It must also end with a final <code>/</code>.</td>
     </tr>
     <tr>
-      <td>tcfEnabled</td>
+      <td>embedTCFStub</td>
       <td>boolean</td>
       <td><code>true</code></td>
-      <td>Define whether the IAB TCF is enabled for the notice. This property also defines whether the TCF stub should be embedded on the page. This property overrides any value defined in an inline config or the Didomi Console.</td>
+      <td>Define whether the IAB TCF stub is embedded on the page before loading the SDK. If your consent notice uses the IAB TCF, we recommend embedding the IAB TCF stub to optimize the communication with vendors.</td>
     </tr>
     <tr>
       <td>onReady</td>
@@ -496,7 +496,7 @@ class DidomiDemo extends Component {
   }
 }
   ```
- 
+
 ## Customize the notice
 
 You can use your own custom notice to replace the standard Didomi SDK notices (banner or popup). This option keeps some native behaviors like the position of the notice, the backdrop (for the popup notice) or the logic to decide when to display the notice.
@@ -533,8 +533,8 @@ class NoticeHTML extends Component {
 }
 
 const didomiConfig = {
-  app: {    
-    apiKey: '<Your API key>',        
+  app: {
+    apiKey: '<Your API key>',
     notice: {
       content: {
         html: {
@@ -560,8 +560,8 @@ You can do everything through HTML:
 
   ```js
   const didomiConfig = {
-  app: {    
-    apiKey: '<Your API key>',        
+  app: {
+    apiKey: '<Your API key>',
     notice: {
       content: {
         html: {
@@ -576,7 +576,7 @@ You can do everything through HTML:
 
 <DidomiSDK config={didomiConfig}/>
   ```
- 
+
 ### Didomi SDK Documentation
 
 See [Documentation](https://developers.didomi.io/cmp/web-sdk)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The sooner you instantiate the component, the faster the banner will be displaye
   noticeId="NOTICE_ID" // If you want to target the notice by ID and not by domain
   gdprAppliesGlobally={true}
   sdkPath="https://sdk.privacy-center.org/"
+  tcfEnabled={true}
   onReady={didomi => console.log('Didomi SDK is loaded and ready', didomi)}
   onConsentChanged={cwtToken => console.log('A consent has been given/withdrawn', cwtToken)}
   onNoticeShown={() => console.log('Didomi Notice Shown')}
@@ -84,6 +85,7 @@ const didomiConfig = {
   noticeId="NOTICE_ID" // If you want to target the notice by ID and not by domain
   gdprAppliesGlobally={true}
   sdkPath="https://sdk.privacy-center.org/"
+  tcfEnabled={true}
   onReady={didomi => console.log('Didomi SDK is loaded and ready', didomi)}
   onConsentChanged={cwtToken => console.log('A consent has been given/withdrawn', cwtToken)}
   onNoticeShown={() => console.log('Didomi Notice Shown')}
@@ -153,6 +155,12 @@ The following configuration options can be passed as props to the `DidomiSDK` co
       <td>string</td>
       <td>https://sdk.privacy-center.org/</td>
       <td>Path to load the SDK from. This can be used to load the Didomi SDK from your own custom domain after <a href="https://developers.didomi.io/cmp/web-sdk/self-hosting">setting up a reverse proxy</a>. The property must start with <code>http://</code>, <code>https://</code>, or <code>//</code>. It must also end with a final <code>/</code>.</td>
+    </tr>
+    <tr>
+      <td>tcfEnabled</td>
+      <td>boolean</td>
+      <td><code>true</code></td>
+      <td>Define whether the IAB TCF is enabled for the notice. This property also defines whether the TCF stub should be embedded on the page. This property overrides any value defined in an inline config or the Didomi Console.</td>
     </tr>
     <tr>
       <td>onReady</td>

--- a/index.d.ts
+++ b/index.d.ts
@@ -112,6 +112,7 @@ declare namespace DidomiReact {
     config?: IDidomiConfig;
     gdprAppliesGlobally?: boolean;
     sdkPath?: string;
+    tcfEnabled?: boolean;
     onReady?: OnReadyFunction;
     onConsentChanged?: OnConsentChangedFunction;
     onNoticeShown?(): any;

--- a/nwb.config.js
+++ b/nwb.config.js
@@ -2,15 +2,9 @@ module.exports = {
   type: 'react-component',
   npm: {
     esModules: true,
-    umd: false
+    umd: false,
   },
-  // webpack: {
-  //   define: {
-  //     'process.env': {
-  //       '__REACT_APP_LOADER_URL__': process.env.NODE_ENV === 'production' ?
-  //         JSON.stringify('https://sdk.privacy-center.org/loader.js') :
-  //         JSON.stringify('http://localhost:8080/sdk.js')
-  //     }
-  //   }
-  // }
-}
+  karma: {
+    browsers: ['ChromeHeadless'],
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -3557,6 +3557,11 @@
       "dev": true,
       "optional": true
     },
+    "dset": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-2.0.1.tgz",
+      "integrity": "sha512-nI29OZMRYq36hOcifB6HTjajNAAiBKSXsyWZrq+VniusseuP2OpNlTiYgsaNRSGvpyq5Wjbc2gQLyBdTyWqhnQ=="
+    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "test:coverage": "nwb test-react --coverage",
     "test:watch": "nwb test-react --server"
   },
-  "dependencies": {},
+  "dependencies": {
+    "dset": "^2.0.1"
+  },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import set from 'dset';
 
 const DidomiSDK = ({
   apiKey: apiKeyProp =  null,
@@ -157,15 +158,6 @@ const DidomiSDK = ({
   }
 
   /**
-   * Determine whether the TCF is enabled from the props or from the config
-   */
-  const isTCFEnabled = config && config.app
-    && config.app.vendors
-    && config.app.vendors.iab
-    && typeof config.app.vendors.iab.enabled === 'boolean'
-    ? config.app.vendors.iab.enabled : tcfEnabled;
-
-  /**
    * Initialize the SDK, set the config object and insert the loader.js into the DOM
    */
   const init = () => {
@@ -177,6 +169,9 @@ const DidomiSDK = ({
     // Set the SDK path
     window.didomiConfig.sdkPath = sdkPath;
 
+    // Indicate whether the TCF is enabled or not
+    set(window.didomiConfig, 'app.vendors.iab.enabled', tcfEnabled);
+
     // Embed the Didomi SDK on the page
     window.gdprAppliesGlobally=gdprAppliesGlobally;
     if(noticeId) {
@@ -186,7 +181,7 @@ const DidomiSDK = ({
     }
     
     // Embed the TCF stub if the TCF is enabled
-    if (isTCFEnabled) {
+    if (tcfEnabled) {
       if(iabVersion === 2) {
         // TCF v2
         (function(){function a(e){if(!window.frames[e]){if(document.body&&document.body.firstChild){var t=document.body;var n=document.createElement("iframe");n.style.display="none";n.name=e;n.title=e;t.insertBefore(n,t.firstChild)}else{setTimeout(function(){a(e)},5)}}}function e(n,r,o,c,s){function e(e,t,n,a){if(typeof n!=="function"){return}if(!window[r]){window[r]=[]}var i=false;if(s){i=s(e,t,n)}if(!i){window[r].push({command:e,parameter:t,callback:n,version:a})}}e.stub=true;function t(a){if(!window[n]||window[n].stub!==true){return}if(!a.data){return}var i=typeof a.data==="string";var e;try{e=i?JSON.parse(a.data):a.data}catch(t){return}if(e[o]){var r=e[o];window[n](r.command,r.parameter,function(e,t){var n={};n[c]={returnValue:e,success:t,callId:r.callId};a.source.postMessage(i?JSON.stringify(n):n,"*")},r.version)}}if(typeof window[n]!=="function"){window[n]=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}}e("__tcfapi","__tcfapiBuffer","__tcfapiCall","__tcfapiReturn");a("__tcfapiLocator");})();

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,8 @@ const DidomiSDK = ({
   onPreferencesClickVendorAgree,
   onPreferencesClickVendorDisagree,
   onPreferencesClickVendorSaveChoices,
-  sdkPath = "https://sdk.privacy-center.org/"
+  sdkPath = "https://sdk.privacy-center.org/",
+  tcfEnabled = true
 }) => {
   /**
    * Set all the Didomi event listeners from the props
@@ -156,6 +157,15 @@ const DidomiSDK = ({
   }
 
   /**
+   * Determine whether the TCF is enabled from the props or from the config
+   */
+  const isTCFEnabled = config && config.app
+    && config.app.vendors
+    && config.app.vendors.iab
+    && typeof config.app.vendors.iab.enabled === 'boolean'
+    ? config.app.vendors.iab.enabled : tcfEnabled;
+
+  /**
    * Initialize the SDK, set the config object and insert the loader.js into the DOM
    */
   const init = () => {
@@ -175,13 +185,30 @@ const DidomiSDK = ({
       loaderParams = `target=${document.location.hostname}`;
     }
     
-    if(iabVersion === 2) {
-      // TCF v2
-      (function(){function a(e){if(!window.frames[e]){if(document.body&&document.body.firstChild){var t=document.body;var n=document.createElement("iframe");n.style.display="none";n.name=e;n.title=e;t.insertBefore(n,t.firstChild)}else{setTimeout(function(){a(e)},5)}}}function e(n,r,o,c,s){function e(e,t,n,a){if(typeof n!=="function"){return}if(!window[r]){window[r]=[]}var i=false;if(s){i=s(e,t,n)}if(!i){window[r].push({command:e,parameter:t,callback:n,version:a})}}e.stub=true;function t(a){if(!window[n]||window[n].stub!==true){return}if(!a.data){return}var i=typeof a.data==="string";var e;try{e=i?JSON.parse(a.data):a.data}catch(t){return}if(e[o]){var r=e[o];window[n](r.command,r.parameter,function(e,t){var n={};n[c]={returnValue:e,success:t,callId:r.callId};a.source.postMessage(i?JSON.stringify(n):n,"*")},r.version)}}if(typeof window[n]!=="function"){window[n]=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}}e("__tcfapi","__tcfapiBuffer","__tcfapiCall","__tcfapiReturn");a("__tcfapiLocator");(function(e){var t=document.createElement("script");t.id="spcloader";t.type="text/javascript";t.async=true;t.src=sdkPath+e+"/loader.js?"+loaderParams;t.charset="utf-8";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n)})(apiKey)})();
-    } else {
-      // TCF v1
-      (function(){function r(){if(!window.frames.__cmpLocator){if(document.body&&document.body.firstChild){var e=document.body;var t=document.createElement("iframe");t.style.display="none";t.name="__cmpLocator";t.title="cmpLocator";e.insertBefore(t,e.firstChild)}else{setTimeout(r,5)}}}function e(e,t,r){if(typeof r!=="function"){return}if(!window.__cmpBuffer){window.__cmpBuffer=[]}if(e==="ping"){r({gdprAppliesGlobally:window.gdprAppliesGlobally,cmpLoaded:false},true)}else{window.__cmpBuffer.push({command:e,parameter:t,callback:r})}}e.stub=true;function t(a){if(!window.__cmp||window.__cmp.stub!==true){return}if(!a.data){return}var n=typeof a.data==="string";var e;try{e=n?JSON.parse(a.data):a.data}catch(t){return}if(e.__cmpCall){var o=e.__cmpCall;window.__cmp(o.command,o.parameter,function(e,t){var r={__cmpReturn:{returnValue:e,success:t,callId:o.callId}};a.source.postMessage(n?JSON.stringify(r):r,"*")})}}if(typeof window.__cmp!=="function"){window.__cmp=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}r()})();(function(e){var t=e?e+"/":"";var r=document.createElement("script");r.id="spcloader";r.type="text/javascript";r.async=true;r.src=sdkPath+t+"loader.js?"+loaderParams;r.charset="utf-8";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(r,a)})(apiKey);
+    // Embed the TCF stub if the TCF is enabled
+    if (isTCFEnabled) {
+      if(iabVersion === 2) {
+        // TCF v2
+        (function(){function a(e){if(!window.frames[e]){if(document.body&&document.body.firstChild){var t=document.body;var n=document.createElement("iframe");n.style.display="none";n.name=e;n.title=e;t.insertBefore(n,t.firstChild)}else{setTimeout(function(){a(e)},5)}}}function e(n,r,o,c,s){function e(e,t,n,a){if(typeof n!=="function"){return}if(!window[r]){window[r]=[]}var i=false;if(s){i=s(e,t,n)}if(!i){window[r].push({command:e,parameter:t,callback:n,version:a})}}e.stub=true;function t(a){if(!window[n]||window[n].stub!==true){return}if(!a.data){return}var i=typeof a.data==="string";var e;try{e=i?JSON.parse(a.data):a.data}catch(t){return}if(e[o]){var r=e[o];window[n](r.command,r.parameter,function(e,t){var n={};n[c]={returnValue:e,success:t,callId:r.callId};a.source.postMessage(i?JSON.stringify(n):n,"*")},r.version)}}if(typeof window[n]!=="function"){window[n]=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}}e("__tcfapi","__tcfapiBuffer","__tcfapiCall","__tcfapiReturn");a("__tcfapiLocator");})();
+      } else {
+        // TCF v1
+        (function(){function r(){if(!window.frames.__cmpLocator){if(document.body&&document.body.firstChild){var e=document.body;var t=document.createElement("iframe");t.style.display="none";t.name="__cmpLocator";t.title="cmpLocator";e.insertBefore(t,e.firstChild)}else{setTimeout(r,5)}}}function e(e,t,r){if(typeof r!=="function"){return}if(!window.__cmpBuffer){window.__cmpBuffer=[]}if(e==="ping"){r({gdprAppliesGlobally:window.gdprAppliesGlobally,cmpLoaded:false},true)}else{window.__cmpBuffer.push({command:e,parameter:t,callback:r})}}e.stub=true;function t(a){if(!window.__cmp||window.__cmp.stub!==true){return}if(!a.data){return}var n=typeof a.data==="string";var e;try{e=n?JSON.parse(a.data):a.data}catch(t){return}if(e.__cmpCall){var o=e.__cmpCall;window.__cmp(o.command,o.parameter,function(e,t){var r={__cmpReturn:{returnValue:e,success:t,callId:o.callId}};a.source.postMessage(n?JSON.stringify(r):r,"*")})}}if(typeof window.__cmp!=="function"){window.__cmp=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}r()})();
+      }
     }
+
+    // Embed the SDK
+    const loaderScript = document.createElement('script');
+    loaderScript.id = 'spcloader';
+    loaderScript.type = 'text/javascript';
+    loaderScript.async = true;
+    loaderScript.src = sdkPath + apiKey + '/loader.js?' + loaderParams;
+    loaderScript.charset = 'utf-8';
+
+    const firstScriptTagInDocument = document.getElementsByTagName('script')[0];
+    firstScriptTagInDocument.parentNode.insertBefore(
+      loaderScript,
+      firstScriptTagInDocument
+    );
   }
 
   React.useEffect(() => {
@@ -214,7 +241,8 @@ DidomiSDK.propTypes = {
   onPreferencesClickVendorAgree: PropTypes.func,
   onPreferencesClickVendorDisagree: PropTypes.func,
   onPreferencesClickVendorSaveChoices: PropTypes.func,
-  sdkPath: PropTypes.string
+  sdkPath: PropTypes.string,
+  tcfEnabled: PropTypes.bool,
 }
 
 export { DidomiSDK }

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ const DidomiSDK = ({
   onPreferencesClickVendorDisagree,
   onPreferencesClickVendorSaveChoices,
   sdkPath = "https://sdk.privacy-center.org/",
-  tcfEnabled = true
+  embedTCFStub = true
 }) => {
   /**
    * Set all the Didomi event listeners from the props
@@ -169,9 +169,6 @@ const DidomiSDK = ({
     // Set the SDK path
     window.didomiConfig.sdkPath = sdkPath;
 
-    // Indicate whether the TCF is enabled or not
-    set(window.didomiConfig, 'app.vendors.iab.enabled', tcfEnabled);
-
     // Embed the Didomi SDK on the page
     window.gdprAppliesGlobally=gdprAppliesGlobally;
     if(noticeId) {
@@ -180,8 +177,8 @@ const DidomiSDK = ({
       loaderParams = `target=${document.location.hostname}`;
     }
     
-    // Embed the TCF stub if the TCF is enabled
-    if (tcfEnabled) {
+    // Embed the TCF stub
+    if (embedTCFStub) {
       if(iabVersion === 2) {
         // TCF v2
         (function(){function a(e){if(!window.frames[e]){if(document.body&&document.body.firstChild){var t=document.body;var n=document.createElement("iframe");n.style.display="none";n.name=e;n.title=e;t.insertBefore(n,t.firstChild)}else{setTimeout(function(){a(e)},5)}}}function e(n,r,o,c,s){function e(e,t,n,a){if(typeof n!=="function"){return}if(!window[r]){window[r]=[]}var i=false;if(s){i=s(e,t,n)}if(!i){window[r].push({command:e,parameter:t,callback:n,version:a})}}e.stub=true;function t(a){if(!window[n]||window[n].stub!==true){return}if(!a.data){return}var i=typeof a.data==="string";var e;try{e=i?JSON.parse(a.data):a.data}catch(t){return}if(e[o]){var r=e[o];window[n](r.command,r.parameter,function(e,t){var n={};n[c]={returnValue:e,success:t,callId:r.callId};a.source.postMessage(i?JSON.stringify(n):n,"*")},r.version)}}if(typeof window[n]!=="function"){window[n]=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}}e("__tcfapi","__tcfapiBuffer","__tcfapiCall","__tcfapiReturn");a("__tcfapiLocator");})();
@@ -237,7 +234,7 @@ DidomiSDK.propTypes = {
   onPreferencesClickVendorDisagree: PropTypes.func,
   onPreferencesClickVendorSaveChoices: PropTypes.func,
   sdkPath: PropTypes.string,
-  tcfEnabled: PropTypes.bool,
+  embedTCFStub: PropTypes.bool,
 }
 
 export { DidomiSDK }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -241,47 +241,65 @@ it('sets gdprAppliesGlobally to false', async () => {
 });
 
 describe('TCF stub', () => {
-  it('embeds the TCF stub if the tcfEnabled prop is not provided (TCFv2)', async function () {
-    render(
-      <DidomiSDK
-        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-        iabVersion={2}
-      />,
-      document.body.appendChild(document.createElement('iframe')),
-    );
-
-    await sdkReady();
-
-    expect(typeof window.__tcfapi).toEqual('function');
-    expect(typeof window.__cmp).toEqual('undefined');
-
-    expect(window.didomiConfig.app.vendors.iab.enabled).toEqual(true);
-  });
-
-  it('embeds the TCF stub if the tcfEnabled prop is true (TCFv2)', async function () {
-    render(
-      <DidomiSDK
-        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-        iabVersion={2}
-        tcfEnabled={true}
-      />,
-      document.body.appendChild(document.createElement('iframe')),
-    );
-
-    await sdkReady();
-
-    expect(typeof window.__tcfapi).toEqual('function');
-    expect(typeof window.__cmp).toEqual('undefined');
-
-    expect(window.didomiConfig.app.vendors.iab.enabled).toEqual(true);
-  });
-
-  it('embeds the TCF stub if the tcfEnabled prop is not provided (TCFv1)', async function () {
+  it('embeds the TCF stub if the embedTCFStub prop is not provided (TCFv2)', async function () {
     const config = {
       app: {
         vendors: {
           iab: {
-            version: 1,
+            enabled: false,
+          },
+        },
+      },
+    };
+
+    render(
+      <DidomiSDK
+        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+        iabVersion={2}
+        config={config}
+      />,
+      document.body.appendChild(document.createElement('iframe')),
+    );
+
+    await sdkReady();
+
+    expect(typeof window.__tcfapi).toEqual('function');
+    expect(typeof window.__cmp).toEqual('undefined');
+  });
+
+  it('embeds the TCF stub if the embedTCFStub prop is true (TCFv2)', async function () {
+    const config = {
+      app: {
+        vendors: {
+          iab: {
+            enabled: false,
+          },
+        },
+      },
+    };
+
+    render(
+      <DidomiSDK
+        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+        iabVersion={2}
+        embedTCFStub={true}
+        config={config}
+      />,
+      document.body.appendChild(document.createElement('iframe')),
+    );
+
+    await sdkReady();
+
+    expect(typeof window.__tcfapi).toEqual('function');
+    expect(typeof window.__cmp).toEqual('undefined');
+  });
+
+  it('embeds the TCF stub if the embedTCFStub prop is not provided (TCFv1)', async function () {
+    const config = {
+      app: {
+        vendors: {
+          iab: {
+            enabled: false,
           },
         },
       },
@@ -300,16 +318,14 @@ describe('TCF stub', () => {
 
     expect(typeof window.__cmp).toEqual('function');
     expect(typeof window.__tcfapi).toEqual('undefined');
-
-    expect(window.didomiConfig.app.vendors.iab.enabled).toEqual(true);
   });
 
-  it('embeds the TCF stub if the tcfEnabled prop is true (TCFv1)', async function () {
+  it('embeds the TCF stub if the embedTCFStub prop is true (TCFv1)', async function () {
     const config = {
       app: {
         vendors: {
           iab: {
-            version: 1,
+            enabled: false,
           },
         },
       },
@@ -319,7 +335,7 @@ describe('TCF stub', () => {
       <DidomiSDK
         apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
         iabVersion={1}
-        tcfEnabled={true}
+        embedTCFStub={true}
         config={config}
       />,
       document.body.appendChild(document.createElement('iframe')),
@@ -329,16 +345,14 @@ describe('TCF stub', () => {
 
     expect(typeof window.__cmp).toEqual('function');
     expect(typeof window.__tcfapi).toEqual('undefined');
-
-    expect(window.didomiConfig.app.vendors.iab.enabled).toEqual(true);
   });
 
-  it('does not embed the TCF stub if tcfEnabled prop is set to false', async function () {
+  it('does not embed the TCF stub if embedTCFStub prop is set to false', async function () {
     const config = {
       app: {
         vendors: {
           iab: {
-            enabled: true,
+            enabled: false,
           },
         },
       },
@@ -348,7 +362,7 @@ describe('TCF stub', () => {
       <DidomiSDK
         apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
         iabVersion={2}
-        tcfEnabled={false}
+        embedTCFStub={false}
         config={config}
       />,
       document.body.appendChild(document.createElement('iframe')),
@@ -358,7 +372,5 @@ describe('TCF stub', () => {
 
     expect(window.__tcfapi).toEqual(undefined);
     expect(window.__cmp).toEqual(undefined);
-
-    expect(window.didomiConfig.app.vendors.iab.enabled).toEqual(false);
   });
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -239,3 +239,143 @@ it('sets gdprAppliesGlobally to false', async () => {
 
   expect(window.gdprAppliesGlobally).toEqual(false);
 });
+
+describe('TCF stub', () => {
+  it('embeds the TCF stub if the tcfEnabled prop is not provided (TCFv2)', async function () {
+    render(
+      <DidomiSDK
+        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+        iabVersion={2}
+      />,
+      document.body.appendChild(document.createElement('iframe')),
+    );
+
+    await sdkReady();
+
+    expect(typeof window.__tcfapi).toEqual('function');
+    expect(typeof window.__cmp).toEqual('undefined');
+  });
+
+  it('embeds the TCF stub if the tcfEnabled prop is true (TCFv2)', async function () {
+    render(
+      <DidomiSDK
+        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+        iabVersion={2}
+        tcfEnabled={true}
+      />,
+      document.body.appendChild(document.createElement('iframe')),
+    );
+
+    await sdkReady();
+
+    expect(typeof window.__tcfapi).toEqual('function');
+    expect(typeof window.__cmp).toEqual('undefined');
+  });
+
+  it('embeds the TCF stub if the tcfEnabled prop is not provided (TCFv1)', async function () {
+    const config = {
+      app: {
+        vendors: {
+          iab: {
+            version: 1,
+          },
+        },
+      },
+    };
+
+    render(
+      <DidomiSDK
+        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+        iabVersion={1}
+        config={config}
+      />,
+      document.body.appendChild(document.createElement('iframe')),
+    );
+
+    await sdkReady();
+
+    expect(typeof window.__cmp).toEqual('function');
+    expect(typeof window.__tcfapi).toEqual('undefined');
+  });
+
+  it('embeds the TCF stub if the tcfEnabled prop is true (TCFv1)', async function () {
+    const config = {
+      app: {
+        vendors: {
+          iab: {
+            version: 1,
+          },
+        },
+      },
+    };
+
+    render(
+      <DidomiSDK
+        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+        iabVersion={1}
+        tcfEnabled={true}
+        config={config}
+      />,
+      document.body.appendChild(document.createElement('iframe')),
+    );
+
+    await sdkReady();
+
+    expect(typeof window.__cmp).toEqual('function');
+    expect(typeof window.__tcfapi).toEqual('undefined');
+  });
+
+  it('does not embed the TCF stub if tcfEnabled prop is set to false', async function () {
+    const config = {
+      app: {
+        vendors: {
+          iab: {
+            enabled: false,
+          },
+        },
+      },
+    };
+
+    render(
+      <DidomiSDK
+        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+        iabVersion={2}
+        tcfEnabled={false}
+        config={config}
+      />,
+      document.body.appendChild(document.createElement('iframe')),
+    );
+
+    await sdkReady();
+
+    expect(window.__tcfapi).toEqual(undefined);
+    expect(window.__cmp).toEqual(undefined);
+  });
+
+  it('does not embed the TCF stub if config is set to false', async function () {
+    const config = {
+      app: {
+        vendors: {
+          iab: {
+            enabled: false,
+          },
+        },
+      },
+    };
+
+    render(
+      <DidomiSDK
+        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+        iabVersion={2}
+        tcfEnabled={true}
+        config={config}
+      />,
+      document.body.appendChild(document.createElement('iframe')),
+    );
+
+    await sdkReady();
+
+    expect(window.__tcfapi).toEqual(undefined);
+    expect(window.__cmp).toEqual(undefined);
+  });
+});

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -254,6 +254,8 @@ describe('TCF stub', () => {
 
     expect(typeof window.__tcfapi).toEqual('function');
     expect(typeof window.__cmp).toEqual('undefined');
+
+    expect(window.didomiConfig.app.vendors.iab.enabled).toEqual(true);
   });
 
   it('embeds the TCF stub if the tcfEnabled prop is true (TCFv2)', async function () {
@@ -270,6 +272,8 @@ describe('TCF stub', () => {
 
     expect(typeof window.__tcfapi).toEqual('function');
     expect(typeof window.__cmp).toEqual('undefined');
+
+    expect(window.didomiConfig.app.vendors.iab.enabled).toEqual(true);
   });
 
   it('embeds the TCF stub if the tcfEnabled prop is not provided (TCFv1)', async function () {
@@ -296,6 +300,8 @@ describe('TCF stub', () => {
 
     expect(typeof window.__cmp).toEqual('function');
     expect(typeof window.__tcfapi).toEqual('undefined');
+
+    expect(window.didomiConfig.app.vendors.iab.enabled).toEqual(true);
   });
 
   it('embeds the TCF stub if the tcfEnabled prop is true (TCFv1)', async function () {
@@ -323,6 +329,8 @@ describe('TCF stub', () => {
 
     expect(typeof window.__cmp).toEqual('function');
     expect(typeof window.__tcfapi).toEqual('undefined');
+
+    expect(window.didomiConfig.app.vendors.iab.enabled).toEqual(true);
   });
 
   it('does not embed the TCF stub if tcfEnabled prop is set to false', async function () {
@@ -330,7 +338,7 @@ describe('TCF stub', () => {
       app: {
         vendors: {
           iab: {
-            enabled: false,
+            enabled: true,
           },
         },
       },
@@ -350,32 +358,7 @@ describe('TCF stub', () => {
 
     expect(window.__tcfapi).toEqual(undefined);
     expect(window.__cmp).toEqual(undefined);
-  });
 
-  it('does not embed the TCF stub if config is set to false', async function () {
-    const config = {
-      app: {
-        vendors: {
-          iab: {
-            enabled: false,
-          },
-        },
-      },
-    };
-
-    render(
-      <DidomiSDK
-        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-        iabVersion={2}
-        tcfEnabled={true}
-        config={config}
-      />,
-      document.body.appendChild(document.createElement('iframe')),
-    );
-
-    await sdkReady();
-
-    expect(window.__tcfapi).toEqual(undefined);
-    expect(window.__cmp).toEqual(undefined);
+    expect(window.didomiConfig.app.vendors.iab.enabled).toEqual(false);
   });
 });


### PR DESCRIPTION
This PR introduces a new `embedTCFStub` prop that controls whether the TCF stub should be embedded on the page or not.

Closes #24 