### PR TITLE
Prevent multiple #spcloader <script> on the page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -190,9 +190,17 @@ const DidomiSDK = ({
       }
     }
 
+    const spcloaderId = 'spcloader';
+    const spcloaderScript = document.getElementById(spcloaderId);
+
+    // Didomi is already loaded, no need to add the script again
+    if (spcloaderScript) {
+      return null;
+    }
+
     // Embed the SDK
     const loaderScript = document.createElement('script');
-    loaderScript.id = 'spcloader';
+    loaderScript.id = spcloaderId;
     loaderScript.type = 'text/javascript';
     loaderScript.async = true;
     loaderScript.src = sdkPath + apiKey + '/loader.js?' + loaderParams;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -158,6 +158,28 @@ it('loads the Didomi SDK with a specific notice ID (TCFv2)', async () => {
   );
 });
 
+it('loads the Didomi SDK only one time even if component is rendered multiple times', async () => {
+  render(
+    <DidomiSDK
+      apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+    />,
+    document.body.appendChild(document.createElement('DIV'))
+  );
+
+  render(
+    <DidomiSDK
+      apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+    />,
+    document.body.appendChild(document.createElement('DIV'))
+  );
+
+  await sdkReady();
+
+  // Ensure that the SDK is correctly embedded on the page
+  const sdkScript = document.querySelectorAll('#spcloader');
+  expect(sdkScript.length).toEqual(1);
+});
+
 it('calls onReady', async () => {
   let ready = false;
   const onReady = () => (ready = true);

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -20,6 +20,11 @@ function sdkReady() {
 beforeEach(function () {
   this.timeout(5000);
 
+  const didomiScripts = document.querySelectorAll('#spcloader');
+  didomiScripts.forEach(scriptTag => {
+    scriptTag.parentNode.removeChild(scriptTag)
+  })
+
   delete window.didomiOnReady;
   delete window.didomiEventListeners;
   delete window.Didomi;


### PR DESCRIPTION
Hello Didomi !

As seen with your support, here's a PR that add a little check to prevent multiple Didomi SDKs being loaded on the same page. This can append when 
- there are multiple React apps (eg. multiple `ReactDOM.render`) on the same page, each app containing a `<DidomiSDK />` component
- the React tree containing `<DidomiSDK />` changes so much that React renders a brand new `<DidomiSDK />` so the `init()` function is called again.

This can leads to multiple SDK being loaded on the page (ie multiple identical `<script id="#spcloader" ..`  and multiple  `<div id="didomi-host"`)


