### PR TITLE
Fix for  `OnConsentChangedFunction` function signature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ branches:
     - master
 
 script:
-  - npm run clean
-  - npm run build
   - npm run lint
+  - npm run clean
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,6 @@ branches:
     - master
 
 script:
+  - npm run clean
   - npm run lint
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,6 @@ branches:
 
 script:
   - npm run clean
+  - npm run build
   - npm run lint
   - npm test

--- a/index.d.ts
+++ b/index.d.ts
@@ -123,7 +123,7 @@ declare namespace DidomiReact {
     [key: string]: any;
   }
 
-  export type OnConsentChangedFunction = (consentToken: string) => any;
+  export type OnConsentChangedFunction = (consentToken: any) => any;
   export type OnPreferencesClickPurposeFunction = (purposeId: string) => any;
   export type OnPreferencesClickVendorFunction = (vendorId: string) => any;
   export type OnReadyFunction = (didomi: IDidomiObject) => any;

--- a/index.d.ts
+++ b/index.d.ts
@@ -123,6 +123,10 @@ declare namespace DidomiReact {
     [key: string]: any;
   }
 
+  /**
+  * Receives a consent web token. 
+  *   See: https://github.com/didomi/cwt-node/blob/master/src/token.js
+  */
   export type OnConsentChangedFunction = (consentToken: any) => any;
   export type OnPreferencesClickPurposeFunction = (purposeId: string) => any;
   export type OnPreferencesClickVendorFunction = (vendorId: string) => any;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@didomi/react",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "didomi-react-test React component",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
## Description
This PR update `OnConsentChangedFunction` function signature to make `consentToken` parameter type `any` (`Object`).  Didomi WEB SDK calls this function with `CWT` object and not a `string`.

## Summary of changes
- update `OnConsentChangedFunction` type definition in `index.d.ts` file;
- update @didomi/react `version` from `1.8.0` to `1.8.1` in  `package.json'.

## Related Issue
[argument 'consentToken' of 'onConsentChanged' value is not a string but a CWT from didomi/cwt-node #45](https://github.com/didomi/react/issues/45#issue-950514528)