### PR TITLE
Add support for CTV notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The sooner you instantiate the component, the faster the banner will be displaye
   apiKey="API_KEY"
   iabVersion={2} // If you want to support the TCF v1∏, don't forget to change this value, even if you selected the TCF v2 in the console. This parameter will load the correct stub in the React Component
   noticeId="NOTICE_ID" // If you want to target the notice by ID and not by domain
+  platform="ctv" // If you want to target a CTV notice, default value is null
   gdprAppliesGlobally={true}
   sdkPath="https://sdk.privacy-center.org/"
   embedTCFStub={true}

--- a/index.d.ts
+++ b/index.d.ts
@@ -193,6 +193,7 @@ declare namespace DidomiReact {
     apiKey?: string;
     iabVersion?: number;
     noticeId?: string;
+    platform?: string;
     config?: IDidomiConfig;
     gdprAppliesGlobally?: boolean;
     sdkPath?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@didomi/react",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@didomi/react",
-      "version": "1.8.4",
+      "version": "1.8.5",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.8.1"

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const DidomiSDK = ({
   apiKey: apiKeyProp = null,
   iabVersion = 2,
   noticeId = null,
+  platform = null,
   config = {},
   gdprAppliesGlobally: gdprAppliesGloballyProp = true,
   onReady,
@@ -172,6 +173,9 @@ const DidomiSDK = ({
     window.gdprAppliesGlobally = gdprAppliesGlobally;
     if (noticeId) {
       loaderParams = `target_type=notice&target=${noticeId}`;
+      if (platform) {
+        loaderParams = `platform=${platform}&${loaderParams}`;
+      }
     } else {
       loaderParams = `target=${document.location.hostname}`;
     }
@@ -224,6 +228,7 @@ DidomiSDK.propTypes = {
   apiKey: PropTypes.string,
   iabVersion: PropTypes.number,
   noticeId: PropTypes.string,
+  platform: PropTypes.string,
   config: PropTypes.object,
   gdprAppliesGlobally: PropTypes.bool,
   onReady: PropTypes.func,

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -99,6 +99,27 @@ it('loads the Didomi SDK with a specific notice ID (TCFv2)', async () => {
   );
 });
 
+it('loads the Didomi SDK with a specific platform (CTV)', async () => {
+  render(
+    <DidomiSDK
+      apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+      iabVersion={2}
+      noticeId="noticeId"
+      platform="ctv"
+    />,
+    document.body.appendChild(document.createElement('DIV')),
+  );
+
+  await sdkReady();
+
+  // Ensure that the SDK is correctly embedded on the page
+  const sdkScript = document.querySelector('#spcloader');
+  expect(sdkScript).toExist();
+  expect(sdkScript.src).toEqual(
+    'https://sdk.privacy-center.org/03f1af55-a479-4c1f-891a-7481345171ce/loader.js?platform=ctv&target_type=notice&target=noticeId',
+  );
+});
+
 it('loads and initializes the Didomi SDK (TCFv1)', async () => {
   render(
     <DidomiSDK apiKey="03f1af55-a479-4c1f-891a-7481345171ce" iabVersion={1} />,
@@ -161,6 +182,27 @@ it('loads the Didomi SDK with a specific notice ID (TCFv2)', async () => {
   expect(sdkScript).toExist();
   expect(sdkScript.src).toEqual(
     'https://sdk.privacy-center.org/03f1af55-a479-4c1f-891a-7481345171ce/loader.js?target_type=notice&target=noticeId',
+  );
+});
+
+it('loads the Didomi SDK with a specific platform (CTV)', async () => {
+  render(
+    <DidomiSDK
+      apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+      iabVersion={1}
+      noticeId="noticeId"
+      platform="ctv"
+    />,
+    document.body.appendChild(document.createElement('DIV')),
+  );
+
+  await sdkReady();
+
+  // Ensure that the SDK is correctly embedded on the page
+  const sdkScript = document.querySelector('#spcloader');
+  expect(sdkScript).toExist();
+  expect(sdkScript.src).toEqual(
+    'https://sdk.privacy-center.org/03f1af55-a479-4c1f-891a-7481345171ce/loader.js?platform=ctv&target_type=notice&target=noticeId',
   );
 });
 


### PR DESCRIPTION
👋 Hello guys,

I notice that there is no option to configure the web SDK for CTV in the lib (https://developers.didomi.io/cmp/web-sdk/getting-started#web-based-ctv-application).

Here is a PR to allow the SDK to be configured for CTV by adding the query param `platform=ctv` from configuration.

Thanks for your reviews! 