### PR TITLE
feat: add getCurrentUserStatus types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -114,6 +114,26 @@ declare namespace DidomiReact {
     };
   }
 
+  type CurrentUserStatusValue<T extends string> = {
+    [K in T]: {
+      id: K;
+      enabled: boolean;
+    };
+  };
+
+  /**
+   * Should match: https://developers.didomi.io/cmp/web-sdk/reference/api#getcurrentuserstatus
+   */
+  interface ICurrentUserStatus {
+    addtl_consent: string;
+    consent_string: string;
+    regulation: string;
+    created: string;
+    updated: string;
+    user_id: string;
+    purposes: CurrentUserStatusValue<string>;
+    vendors: CurrentUserStatusValue<string>;
+  }
   /**
    * Didomi Object (exported by the SDK as window.Didomi)
    */
@@ -134,6 +154,7 @@ declare namespace DidomiReact {
     getPurposes(): any;
     getRequiredPurposeIds(): any;
     getTranslationAsHTML(): any;
+    getCurrentUserStatus(): ICurrentUserStatus;
     getUserStatus(): IUserStatus;
     getUserConsentStatusForAll(): IUserConsentStatus;
     getUserConsentToken(): any;

--- a/index.d.ts
+++ b/index.d.ts
@@ -155,6 +155,9 @@ declare namespace DidomiReact {
     getRequiredPurposeIds(): any;
     getTranslationAsHTML(): any;
     getCurrentUserStatus(): ICurrentUserStatus;
+    /**
+     * @deprecated Please use getCurrentUserStatus instead
+     */
     getUserStatus(): IUserStatus;
     getUserConsentStatusForAll(): IUserConsentStatus;
     getUserConsentToken(): any;


### PR DESCRIPTION
Adds the missing [getCurrentUserStatus](https://developers.didomi.io/cmp/web-sdk/reference/api#getcurrentuserstatus) types to the component interface.