### PR TITLE
Remove TCFv1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ The sooner you instantiate the component, the faster the banner will be displaye
 ```jsx
 <DidomiSDK
   apiKey="API_KEY"
-  iabVersion={2} // If you want to support the TCF v1∏, don't forget to change this value, even if you selected the TCF v2 in the console. This parameter will load the correct stub in the React Component
   noticeId="NOTICE_ID" // If you want to target the notice by ID and not by domain
   platform="ctv" // If you want to target a CTV notice, default value is null
   gdprAppliesGlobally={true}
@@ -58,8 +57,10 @@ The sooner you instantiate the component, the faster the banner will be displaye
 />
 ```
 
-The Didomi SDK will automatically download its configuration from the Didomi Console.  
+The Didomi SDK will automatically download its configuration from the Didomi Console.
 Configuration modifications applied through the Didomi Console will be distributed to your users automatically, without modifications to your code.
+
+The component only supports the IAB TCF v2. When `embedTCFStub` is enabled, the TCF v2 stub is embedded automatically before loading the SDK.
 
 ### Instantiate the component with a local configuration
 
@@ -84,7 +85,6 @@ const didomiConfig = {
 
 <DidomiSDK
   config={didomiConfig}
-  iabVersion={2} // If you want to support the TCF v1, don't forget to change this value. This parameter will load the correct stub in the React Component
   noticeId="NOTICE_ID" // If you want to target the notice by ID and not by domain
   gdprAppliesGlobally={true}
   sdkPath="https://sdk.privacy-center.org/"
@@ -127,12 +127,6 @@ The following configuration options can be passed as props to the `DidomiSDK` co
       <td>string</td>
       <td>null</td>
       <td>Your API Key</td>
-    </tr>
-    <tr>
-      <td>iabVersion</td>
-      <td>number</td>
-      <td>1</td>
-      <td>The IAB TCF Version you want to support (1 or 2)</td>
     </tr>
     <tr>
       <td>noticeId</td>
@@ -500,7 +494,6 @@ class DidomiDemo extends Component {
     return <div>
       <h1>Didomi React Demo</h1>
       <DidomiSDK
-        iabVersion={2}
         config={didomiConfig}
         gdprAppliesGlobally={true}
         onReady={this.onDidomiReady.bind(this)}

--- a/index.d.ts
+++ b/index.d.ts
@@ -215,7 +215,6 @@ declare namespace DidomiReact {
    */
   interface IDidomiSDKProps {
     apiKey?: string;
-    iabVersion?: number;
     noticeId?: string;
     platform?: string;
     config?: IDidomiConfig;

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 const DidomiSDK = ({
   apiKey: apiKeyProp = null,
-  iabVersion = 2,
   noticeId = null,
   platform = null,
   config = {},
@@ -193,15 +192,9 @@ const DidomiSDK = ({
 
     // Embed the TCF stub
     if (embedTCFStub) {
-      if (iabVersion === 2) {
-        // TCF v2
-        // prettier-ignore
-        (function(){function a(e){if(!window.frames[e]){if(document.body&&document.body.firstChild){var t=document.body;var n=document.createElement("iframe");n.style.display="none";n.name=e;n.title=e;t.insertBefore(n,t.firstChild)}else{setTimeout(function(){a(e)},5)}}}function e(n,r,o,c,s){function e(e,t,n,a){if(typeof n!=="function"){return}if(!window[r]){window[r]=[]}var i=false;if(s){i=s(e,t,n)}if(!i){window[r].push({command:e,parameter:t,callback:n,version:a})}}e.stub=true;function t(a){if(!window[n]||window[n].stub!==true){return}if(!a.data){return}var i=typeof a.data==="string";var e;try{e=i?JSON.parse(a.data):a.data}catch(t){return}if(e[o]){var r=e[o];window[n](r.command,r.parameter,function(e,t){var n={};n[c]={returnValue:e,success:t,callId:r.callId};a.source.postMessage(i?JSON.stringify(n):n,"*")},r.version)}}if(typeof window[n]!=="function"){window[n]=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}}e("__tcfapi","__tcfapiBuffer","__tcfapiCall","__tcfapiReturn");a("__tcfapiLocator");})();
-      } else {
-        // TCF v1
-        // prettier-ignore
-        (function(){function r(){if(!window.frames.__cmpLocator){if(document.body&&document.body.firstChild){var e=document.body;var t=document.createElement("iframe");t.style.display="none";t.name="__cmpLocator";t.title="cmpLocator";e.insertBefore(t,e.firstChild)}else{setTimeout(r,5)}}}function e(e,t,r){if(typeof r!=="function"){return}if(!window.__cmpBuffer){window.__cmpBuffer=[]}if(e==="ping"){r({gdprAppliesGlobally:window.gdprAppliesGlobally,cmpLoaded:false},true)}else{window.__cmpBuffer.push({command:e,parameter:t,callback:r})}}e.stub=true;function t(a){if(!window.__cmp||window.__cmp.stub!==true){return}if(!a.data){return}var n=typeof a.data==="string";var e;try{e=n?JSON.parse(a.data):a.data}catch(t){return}if(e.__cmpCall){var o=e.__cmpCall;window.__cmp(o.command,o.parameter,function(e,t){var r={__cmpReturn:{returnValue:e,success:t,callId:o.callId}};a.source.postMessage(n?JSON.stringify(r):r,"*")})}}if(typeof window.__cmp!=="function"){window.__cmp=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}r()})();
-      }
+      // TCF v2
+      // prettier-ignore
+      (function(){function a(e){if(!window.frames[e]){if(document.body&&document.body.firstChild){var t=document.body;var n=document.createElement("iframe");n.style.display="none";n.name=e;n.title=e;t.insertBefore(n,t.firstChild)}else{setTimeout(function(){a(e)},5)}}}function e(n,r,o,c,s){function e(e,t,n,a){if(typeof n!=="function"){return}if(!window[r]){window[r]=[]}var i=false;if(s){i=s(e,t,n)}if(!i){window[r].push({command:e,parameter:t,callback:n,version:a})}}e.stub=true;function t(a){if(!window[n]||window[n].stub!==true){return}if(!a.data){return}var i=typeof a.data==="string";var e;try{e=i?JSON.parse(a.data):a.data}catch(t){return}if(e[o]){var r=e[o];window[n](r.command,r.parameter,function(e,t){var n={};n[c]={returnValue:e,success:t,callId:r.callId};a.source.postMessage(i?JSON.stringify(n):n,"*")},r.version)}}if(typeof window[n]!=="function"){window[n]=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}}e("__tcfapi","__tcfapiBuffer","__tcfapiCall","__tcfapiReturn");a("__tcfapiLocator");})();
     }
 
     const spcloaderId = 'spcloader';
@@ -237,7 +230,6 @@ const DidomiSDK = ({
 
 DidomiSDK.propTypes = {
   apiKey: PropTypes.string,
-  iabVersion: PropTypes.number,
   noticeId: PropTypes.string,
   platform: PropTypes.string,
   config: PropTypes.object,

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -42,10 +42,7 @@ it('loads and initializes the Didomi SDK', async () => {
     document.body.appendChild(document.createElement('iframe')),
   );
   root.render(
-    <DidomiSDK
-      apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-      country="FR"
-    />,
+    <DidomiSDK apiKey="03f1af55-a479-4c1f-891a-7481345171ce" country="FR" />,
   );
 
   await sdkReady();
@@ -354,7 +351,8 @@ describe('TCF stub', () => {
     expect(Array.isArray(window.__tcfapiBuffer)).toEqual(true);
     expect(window.__tcfapiBuffer.length).toBeGreaterThan(0);
 
-    const lastBufferEntry = window.__tcfapiBuffer[window.__tcfapiBuffer.length - 1];
+    const lastBufferEntry =
+      window.__tcfapiBuffer[window.__tcfapiBuffer.length - 1];
     expect(lastBufferEntry.command).toEqual('ping');
     expect(lastBufferEntry.parameter).toEqual(2);
     expect(typeof lastBufferEntry.callback).toEqual('function');

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -265,169 +265,81 @@ it('sets gdprAppliesGlobally to false', async () => {
 });
 
 describe('TCF stub', () => {
+  // Use an invalid sdkPath to prevent the SDK from loading,
+  // ensuring we test the stub behavior without race conditions
+  const nonLoadingSdkPath = 'about:blank#';
+
+  // Helper to wait for React to render and the stub to be embedded
+  const waitForStub = () => new Promise((resolve) => setTimeout(resolve, 50));
+
   it('embeds the TCF stub if the embedTCFStub prop is not provided', async function () {
-    const config = {
-      app: {
-        vendors: {
-          iab: {
-            enabled: false,
-          },
-        },
-      },
-    };
-
     root = createRoot(
       document.body.appendChild(document.createElement('iframe')),
     );
     root.render(
       <DidomiSDK
         apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-        config={config}
+        sdkPath={nonLoadingSdkPath}
         country="FR"
       />,
     );
 
-    await sdkReady();
+    await waitForStub();
 
     expect(typeof window.__tcfapi).toEqual('function');
-  });
-
-  it('embeds the TCF stub when loading from a custom SDK path', async function () {
-    const config = {
-      app: {
-        vendors: {
-          iab: {
-            enabled: false,
-          },
-        },
-      },
-    };
-
-    root = createRoot(
-      document.body.appendChild(document.createElement('iframe')),
-    );
-    root.render(
-      <DidomiSDK
-        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-        config={config}
-        sdkPath="https://sdk.staging.privacy-center.org/"
-        country="FR"
-      />,
-    );
-
-    await sdkReady();
-
-    expect(typeof window.__tcfapi).toEqual('function');
+    expect(window.__tcfapi.stub).toEqual(true);
   });
 
   it('embeds the TCF stub if the embedTCFStub prop is true', async function () {
-    const config = {
-      app: {
-        vendors: {
-          iab: {
-            enabled: false,
-          },
-        },
-      },
-    };
-
     root = createRoot(
       document.body.appendChild(document.createElement('iframe')),
     );
     root.render(
       <DidomiSDK
         apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+        sdkPath={nonLoadingSdkPath}
         embedTCFStub={true}
-        config={config}
         country="FR"
       />,
     );
 
-    await sdkReady();
+    await waitForStub();
 
     expect(typeof window.__tcfapi).toEqual('function');
-  });
-
-  it('embeds the TCF stub when loading a notice on a platform', async function () {
-    const config = {
-      app: {
-        vendors: {
-          iab: {
-            enabled: false,
-          },
-        },
-      },
-    };
-
-    root = createRoot(
-      document.body.appendChild(document.createElement('iframe')),
-    );
-    root.render(
-      <DidomiSDK
-        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-        config={config}
-        noticeId="noticeId"
-        platform="ctv"
-        country="FR"
-      />,
-    );
-
-    await sdkReady();
-
-    expect(typeof window.__tcfapi).toEqual('function');
+    expect(window.__tcfapi.stub).toEqual(true);
   });
 
   it('does not embed the TCF stub if embedTCFStub prop is set to false', async function () {
-    const config = {
-      app: {
-        vendors: {
-          iab: {
-            enabled: false,
-          },
-        },
-      },
-    };
-
     root = createRoot(
       document.body.appendChild(document.createElement('iframe')),
     );
     root.render(
       <DidomiSDK
         apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+        sdkPath={nonLoadingSdkPath}
         embedTCFStub={false}
-        config={config}
         country="FR"
       />,
     );
 
-    await sdkReady();
+    await waitForStub();
 
     expect(window.__tcfapi).toEqual(undefined);
   });
 
   it('embeds the correct TCF v2 stub structure', async function () {
-    const config = {
-      app: {
-        vendors: {
-          iab: {
-            enabled: false,
-          },
-        },
-      },
-    };
-
     root = createRoot(
       document.body.appendChild(document.createElement('iframe')),
     );
     root.render(
       <DidomiSDK
         apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-        config={config}
+        sdkPath={nonLoadingSdkPath}
         country="FR"
       />,
     );
 
-    await sdkReady();
+    await waitForStub();
 
     // Verify __tcfapi is a stub function
     expect(typeof window.__tcfapi).toEqual('function');
@@ -437,11 +349,7 @@ describe('TCF stub', () => {
     expect(window.frames['__tcfapiLocator']).toExist();
 
     // Verify commands are queued in __tcfapiBuffer
-    const callbackResult = { called: false, data: null };
-    window.__tcfapi('ping', 2, (data, success) => {
-      callbackResult.called = true;
-      callbackResult.data = { data, success };
-    });
+    window.__tcfapi('ping', 2, () => {});
 
     expect(Array.isArray(window.__tcfapiBuffer)).toEqual(true);
     expect(window.__tcfapiBuffer.length).toBeGreaterThan(0);

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -32,6 +32,7 @@ beforeEach(function () {
   delete window.Didomi;
   delete window.didomiConfig;
   delete window.__tcfapi;
+  delete window.__tcfapiBuffer;
   delete window.gdprAppliesGlobally;
   delete window.didomiCountry;
 });
@@ -402,5 +403,52 @@ describe('TCF stub', () => {
     await sdkReady();
 
     expect(window.__tcfapi).toEqual(undefined);
+  });
+
+  it('embeds the correct TCF v2 stub structure', async function () {
+    const config = {
+      app: {
+        vendors: {
+          iab: {
+            enabled: false,
+          },
+        },
+      },
+    };
+
+    root = createRoot(
+      document.body.appendChild(document.createElement('iframe')),
+    );
+    root.render(
+      <DidomiSDK
+        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+        config={config}
+        country="FR"
+      />,
+    );
+
+    await sdkReady();
+
+    // Verify __tcfapi is a stub function
+    expect(typeof window.__tcfapi).toEqual('function');
+    expect(window.__tcfapi.stub).toEqual(true);
+
+    // Verify the __tcfapiLocator iframe is created
+    expect(window.frames['__tcfapiLocator']).toExist();
+
+    // Verify commands are queued in __tcfapiBuffer
+    const callbackResult = { called: false, data: null };
+    window.__tcfapi('ping', 2, (data, success) => {
+      callbackResult.called = true;
+      callbackResult.data = { data, success };
+    });
+
+    expect(Array.isArray(window.__tcfapiBuffer)).toEqual(true);
+    expect(window.__tcfapiBuffer.length).toBeGreaterThan(0);
+
+    const lastBufferEntry = window.__tcfapiBuffer[window.__tcfapiBuffer.length - 1];
+    expect(lastBufferEntry.command).toEqual('ping');
+    expect(lastBufferEntry.parameter).toEqual(2);
+    expect(typeof lastBufferEntry.callback).toEqual('function');
   });
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -32,12 +32,11 @@ beforeEach(function () {
   delete window.Didomi;
   delete window.didomiConfig;
   delete window.__tcfapi;
-  delete window.__cmp;
   delete window.gdprAppliesGlobally;
   delete window.didomiCountry;
 });
 
-it('loads and initializes the Didomi SDK (TCFv2)', async () => {
+it('loads and initializes the Didomi SDK', async () => {
   root = createRoot(
     document.body.appendChild(document.createElement('iframe')),
   );
@@ -62,7 +61,7 @@ it('loads and initializes the Didomi SDK (TCFv2)', async () => {
 
 // This is intentionally not an arrow function, so that the this binding is not lost and the this.timeout(10000) applies
 // Otherwise we will get flaky results. The tests are cut short at 2000ms when fetching data from the specified sdk path
-it('loads the Didomi SDK from a specific SDK path (TCFv2)', async function () {
+it('loads the Didomi SDK from a specific SDK path', async function () {
   this.timeout(10000);
   root = createRoot(document.body.appendChild(document.createElement('DIV')));
   root.render(
@@ -87,7 +86,7 @@ it('loads the Didomi SDK from a specific SDK path (TCFv2)', async function () {
   );
 });
 
-it('loads the Didomi SDK with a specific notice ID (TCFv2)', async () => {
+it('loads the Didomi SDK with a specific notice ID', async () => {
   root = createRoot(document.body.appendChild(document.createElement('DIV')));
   root.render(
     <DidomiSDK
@@ -265,7 +264,7 @@ it('sets gdprAppliesGlobally to false', async () => {
 });
 
 describe('TCF stub', () => {
-  it('embeds the TCF stub if the embedTCFStub prop is not provided (TCFv2)', async function () {
+  it('embeds the TCF stub if the embedTCFStub prop is not provided', async function () {
     const config = {
       app: {
         vendors: {
@@ -290,10 +289,9 @@ describe('TCF stub', () => {
     await sdkReady();
 
     expect(typeof window.__tcfapi).toEqual('function');
-    expect(typeof window.__cmp).toEqual('undefined');
   });
 
-  it('embeds the TCF stub when loading from a custom SDK path (TCFv2)', async function () {
+  it('embeds the TCF stub when loading from a custom SDK path', async function () {
     const config = {
       app: {
         vendors: {
@@ -312,16 +310,16 @@ describe('TCF stub', () => {
         apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
         config={config}
         sdkPath="https://sdk.staging.privacy-center.org/"
+        country="FR"
       />,
     );
 
     await sdkReady();
 
     expect(typeof window.__tcfapi).toEqual('function');
-    expect(typeof window.__cmp).toEqual('undefined');
   });
 
-  it('embeds the TCF stub if the embedTCFStub prop is true (TCFv2)', async function () {
+  it('embeds the TCF stub if the embedTCFStub prop is true', async function () {
     const config = {
       app: {
         vendors: {
@@ -347,10 +345,9 @@ describe('TCF stub', () => {
     await sdkReady();
 
     expect(typeof window.__tcfapi).toEqual('function');
-    expect(typeof window.__cmp).toEqual('undefined');
   });
 
-  it('embeds the TCF stub when loading a notice on a platform (TCFv2)', async function () {
+  it('embeds the TCF stub when loading a notice on a platform', async function () {
     const config = {
       app: {
         vendors: {
@@ -370,13 +367,13 @@ describe('TCF stub', () => {
         config={config}
         noticeId="noticeId"
         platform="ctv"
+        country="FR"
       />,
     );
 
     await sdkReady();
 
     expect(typeof window.__tcfapi).toEqual('function');
-    expect(typeof window.__cmp).toEqual('undefined');
   });
 
   it('does not embed the TCF stub if embedTCFStub prop is set to false', async function () {
@@ -405,6 +402,5 @@ describe('TCF stub', () => {
     await sdkReady();
 
     expect(window.__tcfapi).toEqual(undefined);
-    expect(window.__cmp).toEqual(undefined);
   });
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -32,6 +32,7 @@ beforeEach(function () {
   delete window.Didomi;
   delete window.didomiConfig;
   delete window.__tcfapi;
+  delete window.__cmp;
   delete window.gdprAppliesGlobally;
   delete window.didomiCountry;
 });
@@ -292,6 +293,34 @@ describe('TCF stub', () => {
     expect(typeof window.__cmp).toEqual('undefined');
   });
 
+  it('embeds the TCF stub when loading from a custom SDK path (TCFv2)', async function () {
+    const config = {
+      app: {
+        vendors: {
+          iab: {
+            enabled: false,
+          },
+        },
+      },
+    };
+
+    root = createRoot(
+      document.body.appendChild(document.createElement('iframe')),
+    );
+    root.render(
+      <DidomiSDK
+        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+        config={config}
+        sdkPath="https://sdk.staging.privacy-center.org/"
+      />,
+    );
+
+    await sdkReady();
+
+    expect(typeof window.__tcfapi).toEqual('function');
+    expect(typeof window.__cmp).toEqual('undefined');
+  });
+
   it('embeds the TCF stub if the embedTCFStub prop is true (TCFv2)', async function () {
     const config = {
       app: {
@@ -312,6 +341,35 @@ describe('TCF stub', () => {
         embedTCFStub={true}
         config={config}
         country="FR"
+      />,
+    );
+
+    await sdkReady();
+
+    expect(typeof window.__tcfapi).toEqual('function');
+    expect(typeof window.__cmp).toEqual('undefined');
+  });
+
+  it('embeds the TCF stub when loading a notice on a platform (TCFv2)', async function () {
+    const config = {
+      app: {
+        vendors: {
+          iab: {
+            enabled: false,
+          },
+        },
+      },
+    };
+
+    root = createRoot(
+      document.body.appendChild(document.createElement('iframe')),
+    );
+    root.render(
+      <DidomiSDK
+        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+        config={config}
+        noticeId="noticeId"
+        platform="ctv"
       />,
     );
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -32,7 +32,6 @@ beforeEach(function () {
   delete window.Didomi;
   delete window.didomiConfig;
   delete window.__tcfapi;
-  delete window.__cmp;
   delete window.gdprAppliesGlobally;
   delete window.didomiCountry;
 });
@@ -44,7 +43,6 @@ it('loads and initializes the Didomi SDK (TCFv2)', async () => {
   root.render(
     <DidomiSDK
       apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-      iabVersion={2}
       country="FR"
     />,
   );
@@ -69,7 +67,6 @@ it('loads the Didomi SDK from a specific SDK path (TCFv2)', async function () {
   root.render(
     <DidomiSDK
       apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-      iabVersion={2}
       sdkPath="https://sdk.staging.privacy-center.org/"
       country="FR"
     />,
@@ -94,7 +91,6 @@ it('loads the Didomi SDK with a specific notice ID (TCFv2)', async () => {
   root.render(
     <DidomiSDK
       apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-      iabVersion={2}
       noticeId="noticeId"
       country="FR"
     />,
@@ -115,102 +111,6 @@ it('loads the Didomi SDK with a specific platform (CTV)', async () => {
   root.render(
     <DidomiSDK
       apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-      iabVersion={2}
-      noticeId="noticeId"
-      platform="ctv"
-      country="FR"
-    />,
-  );
-
-  await sdkReady();
-
-  // Ensure that the SDK is correctly embedded on the page
-  const sdkScript = document.querySelector('#spcloader');
-  expect(sdkScript).toExist();
-  expect(sdkScript.src).toEqual(
-    'https://sdk.privacy-center.org/03f1af55-a479-4c1f-891a-7481345171ce/loader.js?platform=ctv&target_type=notice&target=noticeId&country=FR',
-  );
-});
-
-it('loads and initializes the Didomi SDK (TCFv1)', async () => {
-  root = createRoot(
-    document.body.appendChild(document.createElement('iframe')),
-  );
-  root.render(
-    <DidomiSDK
-      apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-      iabVersion={1}
-      country="FR"
-    />,
-  );
-
-  await sdkReady();
-
-  // Ensure that the SDK is correctly embedded on the page
-  const sdkScript = document.querySelector('#spcloader');
-  expect(sdkScript).toExist();
-  expect(sdkScript.src).toEqual(
-    'https://sdk.privacy-center.org/03f1af55-a479-4c1f-891a-7481345171ce/loader.js?target=localhost&country=FR',
-  );
-
-  expect(typeof window.__cmp).toEqual('function');
-});
-
-// This is intentionally not an arrow function, so that the this binding is not lost and the this.timeout(10000) applies
-// Otherwise we will get flaky results. The tests are cut short at 2000ms when fetching data from the specified sdk path
-it('loads the Didomi SDK from a specific SDK path (TCFv1)', async function () {
-  this.timeout(10000);
-  root = createRoot(document.body.appendChild(document.createElement('DIV')));
-  root.render(
-    <DidomiSDK
-      apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-      iabVersion={1}
-      sdkPath="https://sdk.staging.privacy-center.org/"
-      country="FR"
-    />,
-  );
-
-  await sdkReady();
-
-  // Ensure that the SDK is correctly embedded on the page
-  const sdkScript = document.querySelector('#spcloader');
-  expect(sdkScript).toExist();
-  expect(sdkScript.src).toEqual(
-    'https://sdk.staging.privacy-center.org/03f1af55-a479-4c1f-891a-7481345171ce/loader.js?target=localhost&country=FR',
-  );
-
-  expect(window.didomiConfig.sdkPath).toEqual(
-    'https://sdk.staging.privacy-center.org/',
-  );
-});
-
-it('loads the Didomi SDK with a specific notice ID (TCFv1)', async () => {
-  root = createRoot(document.body.appendChild(document.createElement('DIV')));
-  root.render(
-    <DidomiSDK
-      apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-      iabVersion={1}
-      noticeId="noticeId"
-      country="FR"
-    />,
-  );
-
-  await sdkReady();
-
-  // Ensure that the SDK is correctly embedded on the page
-  const sdkScript = document.querySelector('#spcloader');
-  expect(sdkScript).toExist();
-  expect(sdkScript.src).toEqual(
-    'https://sdk.privacy-center.org/03f1af55-a479-4c1f-891a-7481345171ce/loader.js?target_type=notice&target=noticeId&country=FR',
-  );
-});
-
-it('loads the Didomi SDK with a specific platform (CTV) (TCFv1)', async () => {
-  root = createRoot(document.body.appendChild(document.createElement('DIV')));
-  root.render(
-    <DidomiSDK
-      apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-      iabVersion={1}
       noticeId="noticeId"
       platform="ctv"
       country="FR"
@@ -381,7 +281,6 @@ describe('TCF stub', () => {
     root.render(
       <DidomiSDK
         apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-        iabVersion={2}
         config={config}
         country="FR"
       />,
@@ -410,7 +309,6 @@ describe('TCF stub', () => {
     root.render(
       <DidomiSDK
         apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-        iabVersion={2}
         embedTCFStub={true}
         config={config}
         country="FR"
@@ -421,65 +319,6 @@ describe('TCF stub', () => {
 
     expect(typeof window.__tcfapi).toEqual('function');
     expect(typeof window.__cmp).toEqual('undefined');
-  });
-
-  it('embeds the TCF stub if the embedTCFStub prop is not provided (TCFv1)', async function () {
-    const config = {
-      app: {
-        vendors: {
-          iab: {
-            enabled: false,
-          },
-        },
-      },
-    };
-
-    root = createRoot(
-      document.body.appendChild(document.createElement('iframe')),
-    );
-    root.render(
-      <DidomiSDK
-        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-        iabVersion={1}
-        config={config}
-        country="FR"
-      />,
-    );
-
-    await sdkReady();
-
-    expect(typeof window.__cmp).toEqual('function');
-    expect(typeof window.__tcfapi).toEqual('undefined');
-  });
-
-  it('embeds the TCF stub if the embedTCFStub prop is true (TCFv1)', async function () {
-    const config = {
-      app: {
-        vendors: {
-          iab: {
-            enabled: false,
-          },
-        },
-      },
-    };
-
-    root = createRoot(
-      document.body.appendChild(document.createElement('iframe')),
-    );
-    root.render(
-      <DidomiSDK
-        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-        iabVersion={1}
-        embedTCFStub={true}
-        config={config}
-        country="FR"
-      />,
-    );
-
-    await sdkReady();
-
-    expect(typeof window.__cmp).toEqual('function');
-    expect(typeof window.__tcfapi).toEqual('undefined');
   });
 
   it('does not embed the TCF stub if embedTCFStub prop is set to false', async function () {
@@ -499,7 +338,6 @@ describe('TCF stub', () => {
     root.render(
       <DidomiSDK
         apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
-        iabVersion={2}
         embedTCFStub={false}
         config={config}
         country="FR"


### PR DESCRIPTION
## Summary
- remove TCFv1 branching and configuration options so the component always embeds the TCFv2 stub
- update documentation and type definitions to reflect TCFv2-only support
- clean up tests to align with the removal of TCFv1 behavior

## Testing
- Tests updated and passing


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932f2fa4b5c832d8e197eecc5c9b139)