### PR TITLE
feat: add gpp stub option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The sooner you instantiate the component, the faster the banner will be displaye
   gdprAppliesGlobally={true}
   sdkPath="https://sdk.privacy-center.org/"
   embedTCFStub={true}
+  embedGPPStub={false} // Set to true to embed the IAB GPP stub before loading the SDK
   country="FR" // Override the user's country (ISO 3166-1 alpha-2 code)
   region="IDF" // Override the user's region (ISO 3166-2 code)
   onReady={didomi => console.log('Didomi SDK is loaded and ready', didomi)}
@@ -61,6 +62,8 @@ The Didomi SDK will automatically download its configuration from the Didomi Con
 Configuration modifications applied through the Didomi Console will be distributed to your users automatically, without modifications to your code.
 
 The component only supports the IAB TCF v2. When `embedTCFStub` is enabled, the TCF v2 stub is embedded automatically before loading the SDK.
+
+If your consent notice also uses the IAB GPP framework, you can opt in to embedding the GPP stub by setting `embedGPPStub={true}`. The GPP stub is not embedded by default.
 
 ### Instantiate the component with a local configuration
 
@@ -158,6 +161,12 @@ The following configuration options can be passed as props to the `DidomiSDK` co
       <td>boolean</td>
       <td><code>true</code></td>
       <td>Define whether the IAB TCF stub is embedded on the page before loading the SDK. If your consent notice uses the IAB TCF, we recommend embedding the IAB TCF stub to optimize the communication with vendors.</td>
+    </tr>
+    <tr>
+      <td>embedGPPStub</td>
+      <td>boolean</td>
+      <td><code>false</code></td>
+      <td>Define whether the IAB GPP stub is embedded on the page before loading the SDK. Enable this when your consent notice uses the IAB GPP framework so that vendor calls made before the SDK finishes loading are queued and replayed.</td>
     </tr>
     <tr>
       <td>country</td>

--- a/index.d.ts
+++ b/index.d.ts
@@ -221,6 +221,7 @@ declare namespace DidomiReact {
     gdprAppliesGlobally?: boolean;
     sdkPath?: string;
     embedTCFStub?: boolean;
+    embedGPPStub?: boolean;
     country?: string;
     region?: string;
     onReady?: OnReadyFunction;

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const DidomiSDK = ({
   onPreferencesClickVendorSaveChoices,
   sdkPath = 'https://sdk.privacy-center.org/',
   embedTCFStub = true,
+  embedGPPStub = false,
   country = null,
   region = null,
 }) => {
@@ -197,6 +198,13 @@ const DidomiSDK = ({
       (function(){function a(e){if(!window.frames[e]){if(document.body&&document.body.firstChild){var t=document.body;var n=document.createElement("iframe");n.style.display="none";n.name=e;n.title=e;t.insertBefore(n,t.firstChild)}else{setTimeout(function(){a(e)},5)}}}function e(n,r,o,c,s){function e(e,t,n,a){if(typeof n!=="function"){return}if(!window[r]){window[r]=[]}var i=false;if(s){i=s(e,t,n)}if(!i){window[r].push({command:e,parameter:t,callback:n,version:a})}}e.stub=true;function t(a){if(!window[n]||window[n].stub!==true){return}if(!a.data){return}var i=typeof a.data==="string";var e;try{e=i?JSON.parse(a.data):a.data}catch(t){return}if(e[o]){var r=e[o];window[n](r.command,r.parameter,function(e,t){var n={};n[c]={returnValue:e,success:t,callId:r.callId};a.source.postMessage(i?JSON.stringify(n):n,"*")},r.version)}}if(typeof window[n]!=="function"){window[n]=e;if(window.addEventListener){window.addEventListener("message",t,false)}else{window.attachEvent("onmessage",t)}}}e("__tcfapi","__tcfapiBuffer","__tcfapiCall","__tcfapiReturn");a("__tcfapiLocator");})();
     }
 
+    // Embed the GPP stub
+    if (embedGPPStub) {
+      // GPP CMP API v1.1
+      // prettier-ignore
+      (function(){window.__gpp_addFrame=function(e){if(!window.frames[e])if(document.body){var t=document.createElement("iframe");t.style.cssText="display:none",t.name=e,document.body.appendChild(t)}else window.setTimeout(function(){window.__gpp_addFrame&&window.__gpp_addFrame(e)},10)};window.__gpp_stub=function(){var e=arguments;if(window.__gpp.queue=window.__gpp.queue||[],window.__gpp.events=window.__gpp.events||[],!e.length||1==e.length&&"queue"==e[0])return window.__gpp.queue;if(1==e.length&&"events"==e[0])return window.__gpp.events;var t=e[0],p=e.length>1?e[1]:null,s=e.length>2?e[2]:null;if("ping"===t)p({gppVersion:"1.1",cmpStatus:"stub",cmpDisplayStatus:"hidden",signalStatus:"not ready",supportedAPIs:["2:tcfeuv2","5:tcfcav1","6:uspv1","7:usnatv1","8:uscav1","9:usvav1","10:uscov1","11:usutv1","12:usctv1"],cmpId:0,sectionList:[],applicableSections:[],gppString:"",parsedSections:{}},!0);else if("addEventListener"===t){"lastId"in window.__gpp||(window.__gpp.lastId=0),window.__gpp.lastId++;var n=window.__gpp.lastId;window.__gpp.events.push({id:n,callback:p,parameter:s}),p({eventName:"listenerRegistered",listenerId:n,data:!0,pingData:{gppVersion:"1.1",cmpStatus:"stub",cmpDisplayStatus:"hidden",signalStatus:"not ready",supportedAPIs:["2:tcfeuv2","5:tcfcav1","6:uspv1","7:usnatv1","8:uscav1","9:usvav1","10:uscov1","11:usutv1","12:usctv1"],cmpId:0,sectionList:[],applicableSections:[],gppString:"",parsedSections:{}}},!0)}else if("removeEventListener"===t){for(var a=!1,i=0;i<window.__gpp.events.length;i++)if(window.__gpp.events[i].id==s){window.__gpp.events.splice(i,1),a=!0;break}p({eventName:"listenerRemoved",listenerId:s,data:a,pingData:{gppVersion:"1.1",cmpStatus:"stub",cmpDisplayStatus:"hidden",signalStatus:"not ready",supportedAPIs:["2:tcfeuv2","5:tcfcav1","6:uspv1","7:usnatv1","8:uscav1","9:usvav1","10:uscov1","11:usutv1","12:usctv1"],cmpId:0,sectionList:[],applicableSections:[],gppString:"",parsedSections:{}}},!0)}else"hasSection"===t?p(!1,!0):"getSection"===t||"getField"===t?p(null,!0):window.__gpp.queue.push([].slice.apply(e))};window.__gpp_msghandler=function(e){var t="string"==typeof e.data;try{var p=t?JSON.parse(e.data):e.data}catch(e){p=null}if("object"==typeof p&&null!==p&&"__gppCall"in p){var s=p.__gppCall;window.__gpp&&window.__gpp(s.command,function(p,n){var a={__gppReturn:{returnValue:p,success:n,callId:s.callId}};e.source.postMessage(t?JSON.stringify(a):a,"*")},"parameter"in s?s.parameter:null,"version"in s?s.version:"1.1")}};if(!("__gpp"in window)||"function"!=typeof window.__gpp){window.__gpp=window.__gpp_stub;window.addEventListener("message",window.__gpp_msghandler,!1);window.__gpp_addFrame("__gppLocator")}})();
+    }
+
     const spcloaderId = 'spcloader';
     const spcloaderScript = document.getElementById(spcloaderId);
 
@@ -252,6 +260,7 @@ DidomiSDK.propTypes = {
   onPreferencesClickVendorSaveChoices: PropTypes.func,
   sdkPath: PropTypes.string,
   embedTCFStub: PropTypes.bool,
+  embedGPPStub: PropTypes.bool,
   country: PropTypes.string,
   region: PropTypes.string,
 };

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -33,6 +33,10 @@ beforeEach(function () {
   delete window.didomiConfig;
   delete window.__tcfapi;
   delete window.__tcfapiBuffer;
+  delete window.__gpp;
+  delete window.__gpp_stub;
+  delete window.__gpp_addFrame;
+  delete window.__gpp_msghandler;
   delete window.gdprAppliesGlobally;
   delete window.didomiCountry;
 });
@@ -356,5 +360,114 @@ describe('TCF stub', () => {
     expect(lastBufferEntry.command).toEqual('ping');
     expect(lastBufferEntry.parameter).toEqual(2);
     expect(typeof lastBufferEntry.callback).toEqual('function');
+  });
+});
+
+describe('GPP stub', () => {
+  // Use an invalid sdkPath to prevent the SDK from loading,
+  // ensuring we test the stub behavior without race conditions
+  const nonLoadingSdkPath = 'about:blank#';
+
+  // Helper to wait for React to render and the stub to be embedded
+  const waitForStub = () => new Promise((resolve) => setTimeout(resolve, 50));
+
+  it('does not embed the GPP stub by default', async function () {
+    root = createRoot(
+      document.body.appendChild(document.createElement('iframe')),
+    );
+    root.render(
+      <DidomiSDK
+        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+        sdkPath={nonLoadingSdkPath}
+        country="FR"
+      />,
+    );
+
+    await waitForStub();
+
+    expect(window.__gpp).toEqual(undefined);
+  });
+
+  it('embeds the GPP stub if the embedGPPStub prop is true', async function () {
+    root = createRoot(
+      document.body.appendChild(document.createElement('iframe')),
+    );
+    root.render(
+      <DidomiSDK
+        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+        sdkPath={nonLoadingSdkPath}
+        embedGPPStub={true}
+        country="FR"
+      />,
+    );
+
+    await waitForStub();
+
+    expect(typeof window.__gpp).toEqual('function');
+    expect(window.frames['__gppLocator']).toExist();
+  });
+
+  it('does not embed the GPP stub if embedGPPStub prop is set to false', async function () {
+    root = createRoot(
+      document.body.appendChild(document.createElement('iframe')),
+    );
+    root.render(
+      <DidomiSDK
+        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+        sdkPath={nonLoadingSdkPath}
+        embedGPPStub={false}
+        country="FR"
+      />,
+    );
+
+    await waitForStub();
+
+    expect(window.__gpp).toEqual(undefined);
+  });
+
+  it('embeds the correct GPP stub structure', async function () {
+    root = createRoot(
+      document.body.appendChild(document.createElement('iframe')),
+    );
+    root.render(
+      <DidomiSDK
+        apiKey="03f1af55-a479-4c1f-891a-7481345171ce"
+        sdkPath={nonLoadingSdkPath}
+        embedGPPStub={true}
+        country="FR"
+      />,
+    );
+
+    await waitForStub();
+
+    // Verify __gpp is a stub function
+    expect(typeof window.__gpp).toEqual('function');
+
+    // Verify the __gppLocator iframe is created
+    expect(window.frames['__gppLocator']).toExist();
+
+    // Verify the ping command returns the expected stub payload
+    let pingResponse;
+    let pingSuccess;
+    window.__gpp('ping', (response, success) => {
+      pingResponse = response;
+      pingSuccess = success;
+    });
+
+    expect(pingSuccess).toEqual(true);
+    expect(pingResponse.gppVersion).toEqual('1.1');
+    expect(pingResponse.cmpStatus).toEqual('stub');
+    expect(pingResponse.signalStatus).toEqual('not ready');
+
+    // Verify unknown commands are queued on __gpp.queue
+    window.__gpp('someUnknownCommand', () => {}, 'param');
+
+    expect(Array.isArray(window.__gpp.queue)).toEqual(true);
+    expect(window.__gpp.queue.length).toBeGreaterThan(0);
+
+    const lastQueueEntry = window.__gpp.queue[window.__gpp.queue.length - 1];
+    expect(lastQueueEntry[0]).toEqual('someUnknownCommand');
+    expect(typeof lastQueueEntry[1]).toEqual('function');
+    expect(lastQueueEntry[2]).toEqual('param');
   });
 });


### PR DESCRIPTION
## Add `embedGPPStub` option to `DidomiSDK`
### What
Adds a new optional `embedGPPStub` prop on the `DidomiSDK` React component that injects the IAB GPP CMP API stub (`__gpp`, `__gppLocator`) onto the page before the Didomi SDK loads, mirroring the existing `embedTCFStub` behaviour.
```jsx
<DidomiSDK
  apiKey="API_KEY"
  embedTCFStub={true}
  embedGPPStub={true} // new
/>
```
### Why
The component already pre-embeds the IAB TCF v2 stub so that vendor calls made before `loader.js` finishes loading are queued and replayed. When a notice uses the IAB GPP framework, the same problem exists for `__gpp` calls: without a stub, early calls from vendors are simply lost. Exposing this as a prop lets integrators opt in for GPP-enabled notices without having to inject the stub manually.
### Default
- `embedTCFStub` stays `true` (unchanged).
- `embedGPPStub` defaults to **`false`** — opt-in, so nothing changes for existing integrators. Customers using GPP simply set it to `true`.
### Changes
- `src/index.js`: new `embedGPPStub` prop + minified GPP CMP API v1.1 stub IIFE (sourced from `core/packages/e2e-utils/src/injectors/inject-stubs.ts`), gated on the prop. Added matching `PropTypes.bool` entry.
- `index.d.ts`: added `embedGPPStub?: boolean` to `IDidomiSDKProps`.
- `tests/index.test.js`: new `describe('GPP stub', …)` suite (4 tests) covering default-off, explicit on/off, and the stub structure (`ping` payload + queueing of unknown commands). Added `__gpp*` cleanup in `beforeEach`.
- `README.md`: documented the new prop in the props table, added a short note next to the TCF paragraph, and updated the example component instantiation.
### Verification
- `npm run lint` — passes.
- `npm test` — 19/19 tests pass (including 4 new GPP stub tests).
- `npm run build` — succeeds.
### Out of scope
- Auto-detecting GPP from the SDK config (the React wrapper has no view into regulation config).
- Changing the `embedTCFStub` default or behaviour.
- Adding a USP (`__uspapi`) stub.
